### PR TITLE
Soak Tests updates and results

### DIFF
--- a/rpc_soak_tests/rpc_rally/cinder/create-and-attach-volume.json
+++ b/rpc_soak_tests/rpc_rally/cinder/create-and-attach-volume.json
@@ -9,7 +9,7 @@
                     "name": "Ubuntu 16.04"
                 },
                 "flavor": {
-                    "name": "m1.xlarge"
+                    "name": "m1.medium"
                 },
                 "create_volume_params": {
                     "availability_zone": "nova"
@@ -39,7 +39,7 @@
                     "max": 50
                 },
                 "flavor": {
-                    "name": "m1.large"
+                    "name": "m1.small"
                 },
                 "image": {
                     "name": "Ubuntu 16.04"

--- a/rpc_soak_tests/rpc_rally/heat/create-stack-and-list-output-resource-group.json
+++ b/rpc_soak_tests/rpc_rally/heat/create-stack-and-list-output-resource-group.json
@@ -26,7 +26,7 @@
     "HeatStacks.create_stack_and_list_output_via_API": [
         {
             "args": {
-               "template_path": "samples/tasks/scenarios/heat/templates/resource-group-with-outputs.yaml.template"
+                "template_path": {{resource_group_with_outputs}}
             },
             "runner": {
                 "type": "constant",

--- a/rpc_soak_tests/rpc_rally/heat/create-stack-and-show-output-resource-group.json
+++ b/rpc_soak_tests/rpc_rally/heat/create-stack-and-show-output-resource-group.json
@@ -27,7 +27,7 @@
     "HeatStacks.create_stack_and_show_output_via_API": [
         {
             "args": {
-               "template_path": "samples/tasks/scenarios/heat/templates/resource-group-with-outputs.yaml.template",
+               "template_path": {{resource_group_with_outputs}},
                "output_key": "val1"
             },
             "runner": {

--- a/rpc_soak_tests/rpc_rally/neutron/results/results_0628_212954.txt
+++ b/rpc_soak_tests/rpc_rally/neutron/results/results_0628_212954.txt
@@ -1,0 +1,1390 @@
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NeutronNetworks.create_and_delete_networks": [
+        {
+            "args": {
+                "network_create_args": {}
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 10
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1
+                    }
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  903e8d24-ce02-4a27-b1f5-a50564c958e4: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 903e8d24-ce02-4a27-b1f5-a50564c958e4
+2018-06-28 21:29:56.356 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Starting:  Task validation.
+2018-06-28 21:29:56.364 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Starting:  Task validation of syntax.
+2018-06-28 21:29:56.380 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Completed: Task validation of syntax.
+2018-06-28 21:29:56.380 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Starting:  Task validation of required platforms.
+2018-06-28 21:29:56.386 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Completed: Task validation of required platforms.
+2018-06-28 21:29:56.386 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Starting:  Task validation of semantic.
+2018-06-28 21:29:59.453 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context users@openstack setup()  finished in 2.39 sec
+2018-06-28 21:29:59.889 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context users@openstack cleanup() started
+2018-06-28 21:30:03.307 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context users@openstack cleanup() finished in 3.42 sec
+2018-06-28 21:30:03.307 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Completed: Task validation of semantic.
+2018-06-28 21:30:03.307 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Completed: Task validation.
+2018-06-28 21:30:03.308 15886 INFO rally.api [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 input file is valid.
+2018-06-28 21:30:03.308 15886 INFO rally.api [-] Run Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:30:03.308 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Starting:  Running task.
+2018-06-28 21:30:03.358 15886 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=6ec693ab-a19f-475e-acaa-947d8ca4133d)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_delete_networks", 
+         "description": "Create and delete a network.", 
+         "scenario": {
+            "NeutronNetworks.create_and_delete_networks": {
+               "network_create_args": {}
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1
+               }
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:30:06.232 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context users@openstack setup()  finished in 2.84 sec
+2018-06-28 21:30:06.874 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context quotas@openstack setup()  finished in 0.64 sec
+2018-06-28 21:30:06.875 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context cleanup@openstack setup()  finished in 0.04 msec
+2018-06-28 21:30:06.907 16101 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 1 START
+2018-06-28 21:30:06.913 16102 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 2 START
+2018-06-28 21:30:06.915 16103 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 3 START
+2018-06-28 21:30:06.920 16104 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 4 START
+2018-06-28 21:30:06.923 16110 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 6 START
+2018-06-28 21:30:06.924 16105 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 5 START
+2018-06-28 21:30:06.931 16114 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 8 START
+2018-06-28 21:30:06.931 16116 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 9 START
+2018-06-28 21:30:06.931 16113 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 7 START
+2018-06-28 21:30:06.935 16118 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 10 START
+2018-06-28 21:30:08.652 16103 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 3 END: OK
+2018-06-28 21:30:08.698 16110 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 6 END: OK
+2018-06-28 21:30:08.797 16104 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 4 END: OK
+2018-06-28 21:30:08.865 16113 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 7 END: OK
+2018-06-28 21:30:08.867 16102 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 2 END: OK
+2018-06-28 21:30:08.875 16101 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 1 END: OK
+2018-06-28 21:30:08.912 16114 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 8 END: OK
+2018-06-28 21:30:08.981 16118 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 10 END: OK
+2018-06-28 21:30:09.000 16105 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 5 END: OK
+2018-06-28 21:30:09.024 16116 INFO rally.task.runner [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | ITER: 9 END: OK
+2018-06-28 21:30:09.054 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context cleanup@openstack cleanup() started
+2018-06-28 21:30:25.504 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context cleanup@openstack cleanup() finished in 16.45 sec
+2018-06-28 21:30:25.505 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context quotas@openstack cleanup() started
+2018-06-28 21:30:25.584 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context quotas@openstack cleanup() finished in 79.66 msec
+2018-06-28 21:30:25.585 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context users@openstack cleanup() started
+2018-06-28 21:30:30.547 15886 INFO rally.task.context [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Context users@openstack cleanup() finished in 4.96 sec
+2018-06-28 21:30:31.566 15886 INFO rally.task.engine [-] Load duration is: 2.110784
+2018-06-28 21:30:31.567 15886 INFO rally.task.engine [-] Full runner duration is: 2.171066
+2018-06-28 21:30:31.567 15886 INFO rally.task.engine [-] Full duration is: 27.179964
+2018-06-28 21:30:31.635 15886 INFO rally.task.engine [-] Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 903e8d24-ce02-4a27-b1f5-a50564c958e4: finished
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_delete_networks
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1
+      }
+    }
+  }, 
+  "args": {
+    "network_create_args": {}
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 903e8d24-ce02-4a27-b1f5-a50564c958e4 has 0 error(s)
+--------------------------------------------------------------------------------
+
++---------------------------------------------------------------------------------------------------------------------------+
+|                                                   Response Times (sec)                                                    |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                 | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_network | 0.936     | 1.072        | 1.211        | 1.225        | 1.24      | 1.101     | 100.0%  | 10    |
+| neutron.delete_network | 0.695     | 0.835        | 1.016        | 1.019        | 1.021     | 0.841     | 100.0%  | 10    |
+| total                  | 1.735     | 1.957        | 2.074        | 2.082        | 2.091     | 1.942     | 100.0%  | 10    |
+|  -> duration           | 1.735     | 1.957        | 2.074        | 2.082        | 2.091     | 1.942     | 100.0%  | 10    |
+|  -> idle_duration      | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 10    |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 2.110784
+Full duration: 27.179964
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 903e8d24-ce02-4a27-b1f5-a50564c958e4 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 903e8d24-ce02-4a27-b1f5-a50564c958e4 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 903e8d24-ce02-4a27-b1f5-a50564c958e4 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NeutronNetworks.create_and_delete_subnets": [
+        {
+            "args": {
+                "network_create_args": {},
+                "subnet_create_args": {},
+                "subnet_cidr_start": "1.1.0.0/30",
+                "subnets_per_network": 2
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 10
+            },
+            "context": {
+                "network": {},
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1,
+                        "subnet": -1
+                    }
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  cb1d67b6-2718-4e3a-be86-8079301dd3c2: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: cb1d67b6-2718-4e3a-be86-8079301dd3c2
+2018-06-28 21:30:33.470 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Starting:  Task validation.
+2018-06-28 21:30:33.477 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Starting:  Task validation of syntax.
+2018-06-28 21:30:33.492 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Completed: Task validation of syntax.
+2018-06-28 21:30:33.492 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Starting:  Task validation of required platforms.
+2018-06-28 21:30:33.498 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Completed: Task validation of required platforms.
+2018-06-28 21:30:33.498 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Starting:  Task validation of semantic.
+2018-06-28 21:30:36.466 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context users@openstack setup()  finished in 2.37 sec
+2018-06-28 21:30:36.961 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context users@openstack cleanup() started
+2018-06-28 21:30:40.431 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context users@openstack cleanup() finished in 3.47 sec
+2018-06-28 21:30:40.433 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Completed: Task validation of semantic.
+2018-06-28 21:30:40.433 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Completed: Task validation.
+2018-06-28 21:30:40.434 16470 INFO rally.api [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 input file is valid.
+2018-06-28 21:30:40.435 16470 INFO rally.api [-] Run Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:30:40.435 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Starting:  Running task.
+2018-06-28 21:30:40.497 16470 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=1bfc7834-e3cd-4f62-b942-561ea824413b)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_delete_subnets", 
+         "description": "Create and delete a given number of subnets.", 
+         "scenario": {
+            "NeutronNetworks.create_and_delete_subnets": {
+               "network_create_args": {}, 
+               "subnet_create_args": {}, 
+               "subnet_cidr_start": "1.1.0.0/30", 
+               "subnets_per_network": 2
+            }
+         }, 
+         "contexts": {
+            "network": {}, 
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1, 
+                  "subnet": -1
+               }
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:30:43.523 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context users@openstack setup()  finished in 2.98 sec
+2018-06-28 21:30:44.209 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context quotas@openstack setup()  finished in 0.69 sec
+2018-06-28 21:30:58.613 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context network@openstack setup()  finished in 14.40 sec
+2018-06-28 21:30:58.613 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context cleanup@openstack setup()  finished in 0.04 msec
+2018-06-28 21:30:58.655 16598 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 1 START
+2018-06-28 21:30:58.658 16599 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 2 START
+2018-06-28 21:30:58.663 16600 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 3 START
+2018-06-28 21:30:58.668 16603 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 4 START
+2018-06-28 21:30:58.671 16606 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 5 START
+2018-06-28 21:30:58.679 16611 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 6 START
+2018-06-28 21:30:58.685 16614 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 7 START
+2018-06-28 21:30:58.686 16615 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 8 START
+2018-06-28 21:30:58.691 16618 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 9 START
+2018-06-28 21:30:58.694 16619 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 10 START
+2018-06-28 21:31:03.523 16600 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 3 END: OK
+2018-06-28 21:31:03.939 16611 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 6 END: OK
+2018-06-28 21:31:03.987 16614 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 7 END: OK
+2018-06-28 21:31:04.252 16618 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 9 END: OK
+2018-06-28 21:31:04.504 16615 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 8 END: OK
+2018-06-28 21:31:04.527 16599 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 2 END: OK
+2018-06-28 21:31:04.769 16598 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 1 END: OK
+2018-06-28 21:31:05.686 16619 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 10 END: OK
+2018-06-28 21:31:05.732 16603 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 4 END: OK
+2018-06-28 21:31:06.299 16606 INFO rally.task.runner [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | ITER: 5 END: OK
+2018-06-28 21:31:06.328 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context cleanup@openstack cleanup() started
+2018-06-28 21:31:24.617 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context cleanup@openstack cleanup() finished in 18.29 sec
+2018-06-28 21:31:24.618 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context network@openstack cleanup() started
+2018-06-28 21:31:55.073 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context network@openstack cleanup() finished in 30.45 sec
+2018-06-28 21:31:55.074 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context quotas@openstack cleanup() started
+2018-06-28 21:31:55.141 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context quotas@openstack cleanup() finished in 67.57 msec
+2018-06-28 21:31:55.142 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context users@openstack cleanup() started
+2018-06-28 21:31:59.999 16470 INFO rally.task.context [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Context users@openstack cleanup() finished in 4.86 sec
+2018-06-28 21:32:01.089 16470 INFO rally.task.engine [-] Load duration is: 7.640543
+2018-06-28 21:32:01.089 16470 INFO rally.task.engine [-] Full runner duration is: 7.706094
+2018-06-28 21:32:01.090 16470 INFO rally.task.engine [-] Full duration is: 79.48746
+2018-06-28 21:32:01.160 16470 INFO rally.task.engine [-] Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task cb1d67b6-2718-4e3a-be86-8079301dd3c2: finished
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_delete_subnets
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "network": {}, 
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1, 
+        "subnet": -1
+      }
+    }
+  }, 
+  "args": {
+    "network_create_args": {}, 
+    "subnet_create_args": {}, 
+    "subnet_cidr_start": "1.1.0.0/30", 
+    "subnets_per_network": 2
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task cb1d67b6-2718-4e3a-be86-8079301dd3c2 has 0 error(s)
+--------------------------------------------------------------------------------
+
++-------------------------------------------------------------------------------------------------------------------------------+
+|                                                     Response Times (sec)                                                      |
++----------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                     | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++----------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_subnet (x2) | 2.2       | 2.803        | 4.516        | 4.556        | 4.596     | 3.187     | 100.0%  | 10    |
+| neutron.delete_subnet (x2) | 1.271     | 2.7          | 3.755        | 4.288        | 4.82      | 2.857     | 100.0%  | 10    |
+| total                      | 4.858     | 5.841        | 7.118        | 7.372        | 7.626     | 6.045     | 100.0%  | 10    |
+|  -> duration               | 4.858     | 5.841        | 7.118        | 7.372        | 7.626     | 6.045     | 100.0%  | 10    |
+|  -> idle_duration          | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 10    |
++----------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 7.640543
+Full duration: 79.48746
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report cb1d67b6-2718-4e3a-be86-8079301dd3c2 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export cb1d67b6-2718-4e3a-be86-8079301dd3c2 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report cb1d67b6-2718-4e3a-be86-8079301dd3c2 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NeutronNetworks.create_and_list_networks": [
+        {
+            "args": {
+                "network_create_args": {}
+            },
+            "runner": {
+                "type": "constant",
+                "times": 100,
+                "concurrency": 10
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1
+                    }
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        },
+        {
+            "args": {
+                "network_create_args": {
+                    "provider:network_type": "vxlan"
+                }
+            },
+            "runner": {
+                "type": "constant",
+                "times": 100,
+                "concurrency": 10
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1
+                    }
+                },
+                "roles": ["admin"]
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  295e04fb-67e5-4269-8533-d24d5b91a21e: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 295e04fb-67e5-4269-8533-d24d5b91a21e
+2018-06-28 21:32:03.125 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Starting:  Task validation.
+2018-06-28 21:32:03.137 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Starting:  Task validation of syntax.
+2018-06-28 21:32:03.178 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Completed: Task validation of syntax.
+2018-06-28 21:32:03.179 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Starting:  Task validation of required platforms.
+2018-06-28 21:32:03.190 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Completed: Task validation of required platforms.
+2018-06-28 21:32:03.191 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Starting:  Task validation of semantic.
+2018-06-28 21:32:05.975 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context users@openstack setup()  finished in 2.20 sec
+2018-06-28 21:32:06.860 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context users@openstack cleanup() started
+2018-06-28 21:32:10.040 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context users@openstack cleanup() finished in 3.18 sec
+2018-06-28 21:32:10.040 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Completed: Task validation of semantic.
+2018-06-28 21:32:10.040 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Completed: Task validation.
+2018-06-28 21:32:10.041 17142 INFO rally.api [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e input file is valid.
+2018-06-28 21:32:10.041 17142 INFO rally.api [-] Run Task 295e04fb-67e5-4269-8533-d24d5b91a21e against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:32:10.041 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Starting:  Running task.
+2018-06-28 21:32:10.088 17142 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=0594c646-08f3-43bd-85a7-ce748bea056c)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_list_networks", 
+         "description": "Create a network and then list all networks.", 
+         "scenario": {
+            "NeutronNetworks.create_and_list_networks": {
+               "network_create_args": {}
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1
+               }
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 100, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:32:12.847 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context users@openstack setup()  finished in 2.73 sec
+2018-06-28 21:32:13.460 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context quotas@openstack setup()  finished in 0.61 sec
+2018-06-28 21:32:13.460 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-28 21:32:13.488 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 1 START
+2018-06-28 21:32:13.495 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 2 START
+2018-06-28 21:32:13.499 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 4 START
+2018-06-28 21:32:13.501 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 3 START
+2018-06-28 21:32:13.502 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 5 START
+2018-06-28 21:32:13.511 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 7 START
+2018-06-28 21:32:13.512 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 6 START
+2018-06-28 21:32:13.513 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 9 START
+2018-06-28 21:32:13.513 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 8 START
+2018-06-28 21:32:13.519 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 10 START
+2018-06-28 21:32:14.694 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 6 END: OK
+2018-06-28 21:32:14.700 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 11 START
+2018-06-28 21:32:14.831 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 8 END: OK
+2018-06-28 21:32:14.836 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 12 START
+2018-06-28 21:32:14.874 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 9 END: OK
+2018-06-28 21:32:14.878 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 13 START
+2018-06-28 21:32:14.888 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 2 END: OK
+2018-06-28 21:32:14.892 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 14 START
+2018-06-28 21:32:14.945 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 1 END: OK
+2018-06-28 21:32:14.950 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 15 START
+2018-06-28 21:32:14.970 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 10 END: OK
+2018-06-28 21:32:14.974 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 16 START
+2018-06-28 21:32:15.199 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 5 END: OK
+2018-06-28 21:32:15.204 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 17 START
+2018-06-28 21:32:15.272 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 3 END: OK
+2018-06-28 21:32:15.278 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 18 START
+2018-06-28 21:32:15.401 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 4 END: OK
+2018-06-28 21:32:15.407 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 19 START
+2018-06-28 21:32:15.636 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 7 END: OK
+2018-06-28 21:32:15.643 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 20 START
+2018-06-28 21:32:15.754 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 12 END: OK
+2018-06-28 21:32:15.759 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 21 START
+2018-06-28 21:32:15.923 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 16 END: OK
+2018-06-28 21:32:15.928 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 22 START
+2018-06-28 21:32:16.011 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 11 END: OK
+2018-06-28 21:32:16.012 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 13 END: OK
+2018-06-28 21:32:16.016 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 23 START
+2018-06-28 21:32:16.018 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 24 START
+2018-06-28 21:32:16.037 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 15 END: OK
+2018-06-28 21:32:16.042 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 25 START
+2018-06-28 21:32:16.204 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 14 END: OK
+2018-06-28 21:32:16.208 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 26 START
+2018-06-28 21:32:16.286 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 18 END: OK
+2018-06-28 21:32:16.291 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 27 START
+2018-06-28 21:32:16.294 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 17 END: OK
+2018-06-28 21:32:16.299 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 28 START
+2018-06-28 21:32:16.370 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 19 END: OK
+2018-06-28 21:32:16.375 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 29 START
+2018-06-28 21:32:16.573 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 20 END: OK
+2018-06-28 21:32:16.577 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 30 START
+2018-06-28 21:32:16.784 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 21 END: OK
+2018-06-28 21:32:16.789 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 31 START
+2018-06-28 21:32:17.015 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 24 END: OK
+2018-06-28 21:32:17.020 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 32 START
+2018-06-28 21:32:17.051 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 25 END: OK
+2018-06-28 21:32:17.057 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 33 START
+2018-06-28 21:32:17.101 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 23 END: OK
+2018-06-28 21:32:17.105 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 34 START
+2018-06-28 21:32:17.166 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 26 END: OK
+2018-06-28 21:32:17.172 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 35 START
+2018-06-28 21:32:17.294 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 22 END: OK
+2018-06-28 21:32:17.298 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 36 START
+2018-06-28 21:32:17.424 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 28 END: OK
+2018-06-28 21:32:17.428 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 37 START
+2018-06-28 21:32:17.565 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 29 END: OK
+2018-06-28 21:32:17.570 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 38 START
+2018-06-28 21:32:17.587 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 27 END: OK
+2018-06-28 21:32:17.591 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 39 START
+2018-06-28 21:32:17.852 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 30 END: OK
+2018-06-28 21:32:17.856 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 40 START
+2018-06-28 21:32:18.063 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 31 END: OK
+2018-06-28 21:32:18.068 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 41 START
+2018-06-28 21:32:18.182 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 34 END: OK
+2018-06-28 21:32:18.187 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 42 START
+2018-06-28 21:32:18.285 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 33 END: OK
+2018-06-28 21:32:18.290 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 43 START
+2018-06-28 21:32:18.319 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 35 END: OK
+2018-06-28 21:32:18.323 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 44 START
+2018-06-28 21:32:18.565 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 32 END: OK
+2018-06-28 21:32:18.570 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 45 START
+2018-06-28 21:32:18.571 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 36 END: OK
+2018-06-28 21:32:18.575 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 46 START
+2018-06-28 21:32:18.618 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 37 END: OK
+2018-06-28 21:32:18.622 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 47 START
+2018-06-28 21:32:18.629 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 38 END: OK
+2018-06-28 21:32:18.634 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 48 START
+2018-06-28 21:32:18.686 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 39 END: OK
+2018-06-28 21:32:18.691 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 49 START
+2018-06-28 21:32:18.882 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 40 END: OK
+2018-06-28 21:32:18.887 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 50 START
+2018-06-28 21:32:19.177 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 41 END: OK
+2018-06-28 21:32:19.181 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 51 START
+2018-06-28 21:32:19.369 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 42 END: OK
+2018-06-28 21:32:19.375 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 52 START
+2018-06-28 21:32:19.443 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 43 END: OK
+2018-06-28 21:32:19.448 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 53 START
+2018-06-28 21:32:19.451 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 44 END: OK
+2018-06-28 21:32:19.456 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 54 START
+2018-06-28 21:32:19.802 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 47 END: OK
+2018-06-28 21:32:19.805 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 55 START
+2018-06-28 21:32:19.815 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 45 END: OK
+2018-06-28 21:32:19.820 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 56 START
+2018-06-28 21:32:19.867 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 49 END: OK
+2018-06-28 21:32:19.871 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 57 START
+2018-06-28 21:32:19.976 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 46 END: OK
+2018-06-28 21:32:19.980 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 58 START
+2018-06-28 21:32:20.065 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 48 END: OK
+2018-06-28 21:32:20.070 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 59 START
+2018-06-28 21:32:20.074 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 50 END: OK
+2018-06-28 21:32:20.080 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 60 START
+2018-06-28 21:32:20.444 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 51 END: OK
+2018-06-28 21:32:20.450 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 61 START
+2018-06-28 21:32:20.547 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 52 END: OK
+2018-06-28 21:32:20.552 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 62 START
+2018-06-28 21:32:20.629 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 53 END: OK
+2018-06-28 21:32:20.634 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 63 START
+2018-06-28 21:32:20.645 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 54 END: OK
+2018-06-28 21:32:20.650 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 64 START
+2018-06-28 21:32:20.913 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 56 END: OK
+2018-06-28 21:32:20.918 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 65 START
+2018-06-28 21:32:21.176 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 57 END: OK
+2018-06-28 21:32:21.181 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 66 START
+2018-06-28 21:32:21.245 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 58 END: OK
+2018-06-28 21:32:21.250 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 67 START
+2018-06-28 21:32:21.273 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 59 END: OK
+2018-06-28 21:32:21.279 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 68 START
+2018-06-28 21:32:21.317 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 55 END: OK
+2018-06-28 21:32:21.322 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 69 START
+2018-06-28 21:32:21.420 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 60 END: OK
+2018-06-28 21:32:21.425 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 70 START
+2018-06-28 21:32:21.728 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 61 END: OK
+2018-06-28 21:32:21.733 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 71 START
+2018-06-28 21:32:21.797 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 64 END: OK
+2018-06-28 21:32:21.801 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 72 START
+2018-06-28 21:32:21.806 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 63 END: OK
+2018-06-28 21:32:21.811 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 73 START
+2018-06-28 21:32:21.938 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 62 END: OK
+2018-06-28 21:32:21.943 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 74 START
+2018-06-28 21:32:22.107 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 65 END: OK
+2018-06-28 21:32:22.111 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 75 START
+2018-06-28 21:32:22.608 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 68 END: OK
+2018-06-28 21:32:22.613 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 76 START
+2018-06-28 21:32:22.676 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 70 END: OK
+2018-06-28 21:32:22.681 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 77 START
+2018-06-28 21:32:23.018 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 69 END: OK
+2018-06-28 21:32:23.024 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 78 START
+2018-06-28 21:32:23.072 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 72 END: OK
+2018-06-28 21:32:23.072 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 71 END: OK
+2018-06-28 21:32:23.076 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 79 START
+2018-06-28 21:32:23.078 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 80 START
+2018-06-28 21:32:23.176 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 67 END: OK
+2018-06-28 21:32:23.180 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 66 END: OK
+2018-06-28 21:32:23.181 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 81 START
+2018-06-28 21:32:23.185 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 82 START
+2018-06-28 21:32:23.223 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 73 END: OK
+2018-06-28 21:32:23.227 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 83 START
+2018-06-28 21:32:23.362 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 74 END: OK
+2018-06-28 21:32:23.367 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 84 START
+2018-06-28 21:32:23.830 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 75 END: OK
+2018-06-28 21:32:23.835 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 85 START
+2018-06-28 21:32:23.939 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 76 END: OK
+2018-06-28 21:32:23.944 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 86 START
+2018-06-28 21:32:24.031 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 77 END: OK
+2018-06-28 21:32:24.037 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 87 START
+2018-06-28 21:32:24.343 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 78 END: OK
+2018-06-28 21:32:24.348 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 88 START
+2018-06-28 21:32:24.530 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 82 END: OK
+2018-06-28 21:32:24.536 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 89 START
+2018-06-28 21:32:24.580 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 80 END: OK
+2018-06-28 21:32:24.585 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 90 START
+2018-06-28 21:32:24.609 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 83 END: OK
+2018-06-28 21:32:24.614 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 91 START
+2018-06-28 21:32:24.710 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 84 END: OK
+2018-06-28 21:32:24.715 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 92 START
+2018-06-28 21:32:24.733 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 79 END: OK
+2018-06-28 21:32:24.738 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 93 START
+2018-06-28 21:32:25.089 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 81 END: OK
+2018-06-28 21:32:25.094 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 94 START
+2018-06-28 21:32:25.211 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 85 END: OK
+2018-06-28 21:32:25.216 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 95 START
+2018-06-28 21:32:25.531 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 87 END: OK
+2018-06-28 21:32:25.537 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 96 START
+2018-06-28 21:32:25.649 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 86 END: OK
+2018-06-28 21:32:25.654 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 97 START
+2018-06-28 21:32:25.697 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 88 END: OK
+2018-06-28 21:32:25.702 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 98 START
+2018-06-28 21:32:25.938 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 89 END: OK
+2018-06-28 21:32:25.943 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 99 START
+2018-06-28 21:32:26.195 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 91 END: OK
+2018-06-28 21:32:26.200 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 100 START
+2018-06-28 21:32:26.216 17345 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 93 END: OK
+2018-06-28 21:32:26.348 17333 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 90 END: OK
+2018-06-28 21:32:26.490 17340 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 92 END: OK
+2018-06-28 21:32:26.624 17351 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 94 END: OK
+2018-06-28 21:32:26.722 17348 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 95 END: OK
+2018-06-28 21:32:27.146 17338 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 98 END: OK
+2018-06-28 21:32:27.220 17335 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 97 END: OK
+2018-06-28 21:32:27.270 17344 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 96 END: OK
+2018-06-28 21:32:27.397 17334 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 99 END: OK
+2018-06-28 21:32:27.628 17332 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 100 END: OK
+2018-06-28 21:32:27.656 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context cleanup@openstack cleanup() started
+2018-06-28 21:32:56.668 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context cleanup@openstack cleanup() finished in 29.01 sec
+2018-06-28 21:32:56.669 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context quotas@openstack cleanup() started
+2018-06-28 21:32:56.752 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context quotas@openstack cleanup() finished in 83.43 msec
+2018-06-28 21:32:56.753 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context users@openstack cleanup() started
+2018-06-28 21:33:01.375 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context users@openstack cleanup() finished in 4.62 sec
+2018-06-28 21:33:02.608 17142 INFO rally.task.engine [-] Load duration is: 14.134052
+2018-06-28 21:33:02.609 17142 INFO rally.task.engine [-] Full runner duration is: 14.187434
+2018-06-28 21:33:02.609 17142 INFO rally.task.engine [-] Full duration is: 51.279637
+2018-06-28 21:33:02.820 17142 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=bc205b3a-d7df-40da-ae58-15babf46b2dc)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_list_networks", 
+         "description": "Create a network and then list all networks.", 
+         "scenario": {
+            "NeutronNetworks.create_and_list_networks": {
+               "network_create_args": {
+                  "provider:network_type": "vxlan"
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1
+               }
+            }, 
+            "roles": [
+               "admin"
+            ]
+         }, 
+         "runner": {
+            "constant": {
+               "times": 100, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:33:05.728 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context users@openstack setup()  finished in 2.87 sec
+2018-06-28 21:33:06.332 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context quotas@openstack setup()  finished in 0.60 sec
+2018-06-28 21:33:15.689 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context roles@openstack setup()  finished in 9.36 sec
+2018-06-28 21:33:15.690 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context cleanup@openstack setup()  finished in 0.03 msec
+2018-06-28 21:33:15.717 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 1 START
+2018-06-28 21:33:15.719 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 2 START
+2018-06-28 21:33:15.722 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 3 START
+2018-06-28 21:33:15.726 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 4 START
+2018-06-28 21:33:15.728 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 5 START
+2018-06-28 21:33:15.734 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 6 START
+2018-06-28 21:33:15.734 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 7 START
+2018-06-28 21:33:15.737 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 8 START
+2018-06-28 21:33:15.741 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 9 START
+2018-06-28 21:33:15.749 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 10 START
+2018-06-28 21:33:16.761 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 1 END: OK
+2018-06-28 21:33:16.768 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 11 START
+2018-06-28 21:33:16.773 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 8 END: OK
+2018-06-28 21:33:16.778 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 12 START
+2018-06-28 21:33:16.790 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 2 END: OK
+2018-06-28 21:33:16.796 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 13 START
+2018-06-28 21:33:16.872 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 10 END: OK
+2018-06-28 21:33:16.877 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 14 START
+2018-06-28 21:33:16.930 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 6 END: OK
+2018-06-28 21:33:16.935 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 15 START
+2018-06-28 21:33:17.035 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 7 END: OK
+2018-06-28 21:33:17.041 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 16 START
+2018-06-28 21:33:17.047 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 4 END: OK
+2018-06-28 21:33:17.054 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 17 START
+2018-06-28 21:33:17.074 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 9 END: OK
+2018-06-28 21:33:17.079 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 18 START
+2018-06-28 21:33:17.084 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 3 END: OK
+2018-06-28 21:33:17.088 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 19 START
+2018-06-28 21:33:17.093 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 5 END: OK
+2018-06-28 21:33:17.097 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 20 START
+2018-06-28 21:33:17.626 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 13 END: OK
+2018-06-28 21:33:17.631 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 21 START
+2018-06-28 21:33:17.655 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 11 END: OK
+2018-06-28 21:33:17.659 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 22 START
+2018-06-28 21:33:17.751 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 14 END: OK
+2018-06-28 21:33:17.756 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 23 START
+2018-06-28 21:33:17.783 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 12 END: OK
+2018-06-28 21:33:17.788 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 24 START
+2018-06-28 21:33:17.923 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 15 END: OK
+2018-06-28 21:33:17.928 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 25 START
+2018-06-28 21:33:17.938 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 16 END: OK
+2018-06-28 21:33:17.942 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 26 START
+2018-06-28 21:33:18.024 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 19 END: OK
+2018-06-28 21:33:18.029 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 17 END: OK
+2018-06-28 21:33:18.029 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 27 START
+2018-06-28 21:33:18.034 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 28 START
+2018-06-28 21:33:18.036 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 18 END: OK
+2018-06-28 21:33:18.042 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 29 START
+2018-06-28 21:33:18.208 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 20 END: OK
+2018-06-28 21:33:18.212 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 30 START
+2018-06-28 21:33:18.454 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 21 END: OK
+2018-06-28 21:33:18.460 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 31 START
+2018-06-28 21:33:18.644 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 23 END: OK
+2018-06-28 21:33:18.648 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 32 START
+2018-06-28 21:33:18.739 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 22 END: OK
+2018-06-28 21:33:18.744 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 33 START
+2018-06-28 21:33:18.797 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 24 END: OK
+2018-06-28 21:33:18.802 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 34 START
+2018-06-28 21:33:18.998 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 28 END: OK
+2018-06-28 21:33:19.004 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 35 START
+2018-06-28 21:33:19.026 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 26 END: OK
+2018-06-28 21:33:19.031 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 36 START
+2018-06-28 21:33:19.081 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 30 END: OK
+2018-06-28 21:33:19.086 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 37 START
+2018-06-28 21:33:19.105 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 27 END: OK
+2018-06-28 21:33:19.110 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 38 START
+2018-06-28 21:33:19.131 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 29 END: OK
+2018-06-28 21:33:19.137 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 39 START
+2018-06-28 21:33:19.216 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 25 END: OK
+2018-06-28 21:33:19.221 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 40 START
+2018-06-28 21:33:19.663 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 33 END: OK
+2018-06-28 21:33:19.669 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 41 START
+2018-06-28 21:33:19.709 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 32 END: OK
+2018-06-28 21:33:19.711 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 31 END: OK
+2018-06-28 21:33:19.714 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 42 START
+2018-06-28 21:33:19.716 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 43 START
+2018-06-28 21:33:19.947 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 35 END: OK
+2018-06-28 21:33:19.953 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 44 START
+2018-06-28 21:33:20.010 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 37 END: OK
+2018-06-28 21:33:20.016 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 45 START
+2018-06-28 21:33:20.031 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 36 END: OK
+2018-06-28 21:33:20.035 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 46 START
+2018-06-28 21:33:20.057 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 39 END: OK
+2018-06-28 21:33:20.063 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 47 START
+2018-06-28 21:33:20.117 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 38 END: OK
+2018-06-28 21:33:20.121 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 48 START
+2018-06-28 21:33:20.137 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 40 END: OK
+2018-06-28 21:33:20.143 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 49 START
+2018-06-28 21:33:20.198 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 34 END: OK
+2018-06-28 21:33:20.203 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 50 START
+2018-06-28 21:33:20.484 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 41 END: OK
+2018-06-28 21:33:20.489 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 51 START
+2018-06-28 21:33:20.556 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 43 END: OK
+2018-06-28 21:33:20.561 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 52 START
+2018-06-28 21:33:20.733 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 42 END: OK
+2018-06-28 21:33:20.738 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 53 START
+2018-06-28 21:33:20.833 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 44 END: OK
+2018-06-28 21:33:20.838 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 54 START
+2018-06-28 21:33:20.952 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 46 END: OK
+2018-06-28 21:33:20.956 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 55 START
+2018-06-28 21:33:20.981 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 45 END: OK
+2018-06-28 21:33:20.985 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 56 START
+2018-06-28 21:33:21.140 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 48 END: OK
+2018-06-28 21:33:21.146 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 57 START
+2018-06-28 21:33:21.147 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 49 END: OK
+2018-06-28 21:33:21.152 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 58 START
+2018-06-28 21:33:21.160 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 50 END: OK
+2018-06-28 21:33:21.164 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 59 START
+2018-06-28 21:33:21.254 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 47 END: OK
+2018-06-28 21:33:21.258 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 60 START
+2018-06-28 21:33:21.419 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 51 END: OK
+2018-06-28 21:33:21.423 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 61 START
+2018-06-28 21:33:21.469 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 52 END: OK
+2018-06-28 21:33:21.472 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 62 START
+2018-06-28 21:33:21.560 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 53 END: OK
+2018-06-28 21:33:21.565 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 63 START
+2018-06-28 21:33:21.706 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 54 END: OK
+2018-06-28 21:33:21.711 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 64 START
+2018-06-28 21:33:21.889 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 55 END: OK
+2018-06-28 21:33:21.893 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 65 START
+2018-06-28 21:33:21.954 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 56 END: OK
+2018-06-28 21:33:21.958 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 66 START
+2018-06-28 21:33:22.040 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 58 END: OK
+2018-06-28 21:33:22.044 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 67 START
+2018-06-28 21:33:22.129 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 57 END: OK
+2018-06-28 21:33:22.132 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 68 START
+2018-06-28 21:33:22.191 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 59 END: OK
+2018-06-28 21:33:22.194 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 69 START
+2018-06-28 21:33:22.347 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 60 END: OK
+2018-06-28 21:33:22.351 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 70 START
+2018-06-28 21:33:22.420 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 61 END: OK
+2018-06-28 21:33:22.424 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 71 START
+2018-06-28 21:33:22.490 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 63 END: OK
+2018-06-28 21:33:22.494 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 72 START
+2018-06-28 21:33:22.722 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 62 END: OK
+2018-06-28 21:33:22.726 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 73 START
+2018-06-28 21:33:22.793 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 65 END: OK
+2018-06-28 21:33:22.797 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 74 START
+2018-06-28 21:33:22.897 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 64 END: OK
+2018-06-28 21:33:22.900 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 75 START
+2018-06-28 21:33:22.904 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 67 END: OK
+2018-06-28 21:33:22.909 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 76 START
+2018-06-28 21:33:23.009 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 68 END: OK
+2018-06-28 21:33:23.013 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 77 START
+2018-06-28 21:33:23.155 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 66 END: OK
+2018-06-28 21:33:23.158 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 78 START
+2018-06-28 21:33:23.278 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 69 END: OK
+2018-06-28 21:33:23.281 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 79 START
+2018-06-28 21:33:23.398 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 70 END: OK
+2018-06-28 21:33:23.403 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 80 START
+2018-06-28 21:33:23.557 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 71 END: OK
+2018-06-28 21:33:23.560 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 81 START
+2018-06-28 21:33:23.562 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 72 END: OK
+2018-06-28 21:33:23.562 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 73 END: OK
+2018-06-28 21:33:23.565 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 83 START
+2018-06-28 21:33:23.565 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 82 START
+2018-06-28 21:33:23.694 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 74 END: OK
+2018-06-28 21:33:23.699 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 84 START
+2018-06-28 21:33:23.759 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 76 END: OK
+2018-06-28 21:33:23.764 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 85 START
+2018-06-28 21:33:23.770 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 75 END: OK
+2018-06-28 21:33:23.775 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 86 START
+2018-06-28 21:33:23.912 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 77 END: OK
+2018-06-28 21:33:23.916 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 87 START
+2018-06-28 21:33:24.139 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 79 END: OK
+2018-06-28 21:33:24.143 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 88 START
+2018-06-28 21:33:24.281 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 78 END: OK
+2018-06-28 21:33:24.286 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 89 START
+2018-06-28 21:33:24.442 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 80 END: OK
+2018-06-28 21:33:24.446 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 90 START
+2018-06-28 21:33:24.535 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 83 END: OK
+2018-06-28 21:33:24.541 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 91 START
+2018-06-28 21:33:24.561 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 81 END: OK
+2018-06-28 21:33:24.566 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 92 START
+2018-06-28 21:33:24.632 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 82 END: OK
+2018-06-28 21:33:24.637 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 93 START
+2018-06-28 21:33:24.671 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 86 END: OK
+2018-06-28 21:33:24.676 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 94 START
+2018-06-28 21:33:24.727 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 85 END: OK
+2018-06-28 21:33:24.732 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 95 START
+2018-06-28 21:33:24.771 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 84 END: OK
+2018-06-28 21:33:24.776 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 96 START
+2018-06-28 21:33:24.802 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 87 END: OK
+2018-06-28 21:33:24.807 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 97 START
+2018-06-28 21:33:25.074 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 88 END: OK
+2018-06-28 21:33:25.078 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 98 START
+2018-06-28 21:33:25.298 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 89 END: OK
+2018-06-28 21:33:25.303 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 99 START
+2018-06-28 21:33:25.316 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 90 END: OK
+2018-06-28 21:33:25.321 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 100 START
+2018-06-28 21:33:25.428 18017 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 91 END: OK
+2018-06-28 21:33:25.475 18016 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 92 END: OK
+2018-06-28 21:33:25.518 18039 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 93 END: OK
+2018-06-28 21:33:25.605 18027 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 95 END: OK
+2018-06-28 21:33:25.645 18020 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 94 END: OK
+2018-06-28 21:33:25.735 18018 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 97 END: OK
+2018-06-28 21:33:25.831 18030 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 96 END: OK
+2018-06-28 21:33:25.932 18033 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 98 END: OK
+2018-06-28 21:33:26.248 18024 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 99 END: OK
+2018-06-28 21:33:26.352 18034 INFO rally.task.runner [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | ITER: 100 END: OK
+2018-06-28 21:33:26.378 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context cleanup@openstack cleanup() started
+2018-06-28 21:33:55.223 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context cleanup@openstack cleanup() finished in 28.84 sec
+2018-06-28 21:33:55.224 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context roles@openstack cleanup() started
+2018-06-28 21:33:56.462 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context roles@openstack cleanup() finished in 1.24 sec
+2018-06-28 21:33:56.463 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context quotas@openstack cleanup() started
+2018-06-28 21:33:56.546 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context quotas@openstack cleanup() finished in 82.95 msec
+2018-06-28 21:33:56.546 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context users@openstack cleanup() started
+2018-06-28 21:34:01.604 17142 INFO rally.task.context [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Context users@openstack cleanup() finished in 5.06 sec
+2018-06-28 21:34:03.549 17142 INFO rally.task.engine [-] Load duration is: 10.633369
+2018-06-28 21:34:03.550 17142 INFO rally.task.engine [-] Full runner duration is: 10.678164
+2018-06-28 21:34:03.550 17142 INFO rally.task.engine [-] Full duration is: 58.777158
+2018-06-28 21:34:03.662 17142 INFO rally.task.engine [-] Task 295e04fb-67e5-4269-8533-d24d5b91a21e | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 295e04fb-67e5-4269-8533-d24d5b91a21e: finished
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_list_networks
+args position 0
+args values:
+{
+  "runner": {
+    "times": 100, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1
+      }
+    }
+  }, 
+  "args": {
+    "network_create_args": {}
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 295e04fb-67e5-4269-8533-d24d5b91a21e has 0 error(s)
+--------------------------------------------------------------------------------
+
++---------------------------------------------------------------------------------------------------------------------------+
+|                                                   Response Times (sec)                                                    |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                 | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_network | 0.676     | 0.766        | 1.086        | 1.205        | 1.783     | 0.849     | 100.0%  | 100   |
+| neutron.list_networks  | 0.174     | 0.455        | 0.706        | 0.836        | 1.231     | 0.486     | 100.0%  | 100   |
+| total                  | 0.918     | 1.31         | 1.706        | 1.781        | 2.124     | 1.335     | 100.0%  | 100   |
+|  -> duration           | 0.918     | 1.31         | 1.706        | 1.781        | 2.124     | 1.335     | 100.0%  | 100   |
+|  -> idle_duration      | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 100   |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 14.134052
+Full duration: 51.279637
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_list_networks
+args position 0
+args values:
+{
+  "runner": {
+    "times": 100, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1
+      }
+    }, 
+    "roles": [
+      "admin"
+    ]
+  }, 
+  "args": {
+    "network_create_args": {
+      "provider:network_type": "vxlan"
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 295e04fb-67e5-4269-8533-d24d5b91a21e has 0 error(s)
+--------------------------------------------------------------------------------
+
++---------------------------------------------------------------------------------------------------------------------------+
+|                                                   Response Times (sec)                                                    |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                 | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_network | 0.627     | 0.739        | 0.947        | 1.083        | 1.228     | 0.78      | 100.0%  | 100   |
+| neutron.list_networks  | 0.121     | 0.204        | 0.332        | 0.37         | 0.431     | 0.219     | 100.0%  | 100   |
+| total                  | 0.814     | 0.968        | 1.195        | 1.301        | 1.395     | 0.999     | 100.0%  | 100   |
+|  -> duration           | 0.814     | 0.968        | 1.195        | 1.301        | 1.395     | 0.999     | 100.0%  | 100   |
+|  -> idle_duration      | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 100   |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 10.633369
+Full duration: 58.777158
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 295e04fb-67e5-4269-8533-d24d5b91a21e --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 295e04fb-67e5-4269-8533-d24d5b91a21e --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 295e04fb-67e5-4269-8533-d24d5b91a21e --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NeutronNetworks.create_and_delete_ports": [
+        {
+            "args": {
+                "network_create_args": {},
+                "port_create_args": {},
+                "ports_per_network": 10
+            },
+            "runner": {
+                "type": "constant",
+                "times": 20,
+                "concurrency": 10
+            },
+            "context": {
+                "network": {},
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1,
+                        "port": -1
+                    }
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  21546f10-6ae7-4178-874c-c1d4a85df6f9: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 21546f10-6ae7-4178-874c-c1d4a85df6f9
+2018-06-28 21:34:05.715 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Starting:  Task validation.
+2018-06-28 21:34:05.722 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Starting:  Task validation of syntax.
+2018-06-28 21:34:05.737 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Completed: Task validation of syntax.
+2018-06-28 21:34:05.737 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Starting:  Task validation of required platforms.
+2018-06-28 21:34:05.742 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Completed: Task validation of required platforms.
+2018-06-28 21:34:05.742 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Starting:  Task validation of semantic.
+2018-06-28 21:34:08.783 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context users@openstack setup()  finished in 2.40 sec
+2018-06-28 21:34:09.251 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context users@openstack cleanup() started
+2018-06-28 21:34:13.629 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context users@openstack cleanup() finished in 4.38 sec
+2018-06-28 21:34:13.629 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Completed: Task validation of semantic.
+2018-06-28 21:34:13.630 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Completed: Task validation.
+2018-06-28 21:34:13.630 18876 INFO rally.api [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 input file is valid.
+2018-06-28 21:34:13.631 18876 INFO rally.api [-] Run Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:34:13.631 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Starting:  Running task.
+2018-06-28 21:34:13.682 18876 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=4f1ccd5d-ac02-413e-ae80-251ac0c6faf5)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_delete_ports", 
+         "description": "Create and delete a port.", 
+         "scenario": {
+            "NeutronNetworks.create_and_delete_ports": {
+               "network_create_args": {}, 
+               "port_create_args": {}, 
+               "ports_per_network": 10
+            }
+         }, 
+         "contexts": {
+            "network": {}, 
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1, 
+                  "port": -1
+               }
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 20, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:34:16.557 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context users@openstack setup()  finished in 2.84 sec
+2018-06-28 21:34:17.149 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context quotas@openstack setup()  finished in 0.59 sec
+2018-06-28 21:34:31.024 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context network@openstack setup()  finished in 13.87 sec
+2018-06-28 21:34:31.025 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context cleanup@openstack setup()  finished in 0.04 msec
+2018-06-28 21:34:31.052 19128 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 1 START
+2018-06-28 21:34:31.057 19129 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 2 START
+2018-06-28 21:34:31.058 19130 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 3 START
+2018-06-28 21:34:31.063 19131 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 4 START
+2018-06-28 21:34:31.064 19134 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 5 START
+2018-06-28 21:34:31.071 19140 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 7 START
+2018-06-28 21:34:31.071 19135 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 6 START
+2018-06-28 21:34:31.073 19142 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 8 START
+2018-06-28 21:34:31.080 19147 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 10 START
+2018-06-28 21:34:31.080 19146 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 9 START
+2018-06-28 21:34:50.107 19128 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 1 END: OK
+2018-06-28 21:34:50.114 19128 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 11 START
+2018-06-28 21:34:50.822 19146 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 9 END: OK
+2018-06-28 21:34:50.829 19146 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 12 START
+2018-06-28 21:34:50.835 19147 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 10 END: OK
+2018-06-28 21:34:50.841 19147 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 13 START
+2018-06-28 21:34:51.068 19130 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 3 END: OK
+2018-06-28 21:34:51.072 19142 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 8 END: OK
+2018-06-28 21:34:51.075 19130 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 14 START
+2018-06-28 21:34:51.079 19142 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 15 START
+2018-06-28 21:34:51.222 19131 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 4 END: OK
+2018-06-28 21:34:51.228 19131 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 16 START
+2018-06-28 21:34:51.509 19134 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 5 END: OK
+2018-06-28 21:34:51.516 19134 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 17 START
+2018-06-28 21:34:51.622 19129 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 2 END: OK
+2018-06-28 21:34:51.630 19129 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 18 START
+2018-06-28 21:34:52.092 19140 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 7 END: OK
+2018-06-28 21:34:52.099 19140 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 19 START
+2018-06-28 21:34:52.745 19135 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 6 END: OK
+2018-06-28 21:34:52.752 19135 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 20 START
+2018-06-28 21:35:09.031 19134 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 17 END: OK
+2018-06-28 21:35:09.638 19147 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 13 END: OK
+2018-06-28 21:35:09.858 19128 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 11 END: OK
+2018-06-28 21:35:11.911 19146 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 12 END: OK
+2018-06-28 21:35:11.925 19135 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 20 END: OK
+2018-06-28 21:35:12.134 19140 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 19 END: OK
+2018-06-28 21:35:12.217 19129 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 18 END: OK
+2018-06-28 21:35:12.636 19131 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 16 END: OK
+2018-06-28 21:35:12.812 19142 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 15 END: OK
+2018-06-28 21:35:13.047 19130 INFO rally.task.runner [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | ITER: 14 END: OK
+2018-06-28 21:35:13.068 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context cleanup@openstack cleanup() started
+2018-06-28 21:35:32.174 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context cleanup@openstack cleanup() finished in 19.11 sec
+2018-06-28 21:35:32.175 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context network@openstack cleanup() started
+2018-06-28 21:35:56.385 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context network@openstack cleanup() finished in 24.21 sec
+2018-06-28 21:35:56.385 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context quotas@openstack cleanup() started
+2018-06-28 21:35:56.466 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context quotas@openstack cleanup() finished in 81.31 msec
+2018-06-28 21:35:56.467 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context users@openstack cleanup() started
+2018-06-28 21:36:01.566 18876 INFO rally.task.context [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Context users@openstack cleanup() finished in 5.10 sec
+2018-06-28 21:36:02.492 18876 INFO rally.task.engine [-] Load duration is: 41.992133
+2018-06-28 21:36:02.492 18876 INFO rally.task.engine [-] Full runner duration is: 42.035465
+2018-06-28 21:36:02.493 18876 INFO rally.task.engine [-] Full duration is: 107.875309
+2018-06-28 21:36:02.603 18876 INFO rally.task.engine [-] Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 21546f10-6ae7-4178-874c-c1d4a85df6f9: finished
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_delete_ports
+args position 0
+args values:
+{
+  "runner": {
+    "times": 20, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "network": {}, 
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1, 
+        "port": -1
+      }
+    }
+  }, 
+  "args": {
+    "network_create_args": {}, 
+    "port_create_args": {}, 
+    "ports_per_network": 10
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 21546f10-6ae7-4178-874c-c1d4a85df6f9 has 0 error(s)
+--------------------------------------------------------------------------------
+
++------------------------------------------------------------------------------------------------------------------------------+
+|                                                     Response Times (sec)                                                     |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                    | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_port (x10) | 10.776    | 12.939       | 13.589       | 14.41        | 14.419    | 12.832    | 100.0%  | 20    |
+| neutron.delete_port (x10) | 6.462     | 7.391        | 8.208        | 8.528        | 8.531     | 7.389     | 100.0%  | 20    |
+| total                     | 17.514    | 20.095       | 21.677       | 21.744       | 21.971    | 20.222    | 100.0%  | 20    |
+|  -> duration              | 17.514    | 20.095       | 21.677       | 21.744       | 21.971    | 20.222    | 100.0%  | 20    |
+|  -> idle_duration         | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 20    |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 41.992133
+Full duration: 107.875309
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 21546f10-6ae7-4178-874c-c1d4a85df6f9 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 21546f10-6ae7-4178-874c-c1d4a85df6f9 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 21546f10-6ae7-4178-874c-c1d4a85df6f9 --json --out output.json
+

--- a/rpc_soak_tests/rpc_rally/serial/boot-and-migrate.json
+++ b/rpc_soak_tests/rpc_rally/serial/boot-and-migrate.json
@@ -4,16 +4,16 @@
         {
             "args": {
                 "flavor": {
-                    "name": "m1.large"
+                    "name": "m1.medium"
                 },
                 "image": {
-                    "name": "CentOS 7"
+                    "name": "Ubuntu 16.04"
                 }
             },
             "runner": {
                 "type": "constant",
-                "times": 100,
-                "concurrency": 5
+                "times": 10,
+                "concurrency": 2
             },
             "context": {
                 "users": {

--- a/rpc_soak_tests/rpc_rally/serial/results/results_0628_185235.txt
+++ b/rpc_soak_tests/rpc_rally/serial/results/results_0628_185235.txt
@@ -1,0 +1,7922 @@
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "SwiftObjects.list_and_download_objects_in_containers": [
+        {
+            "runner": {
+                "type": "constant",
+                "times": 2,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 1,
+                    "users_per_tenant": 1
+                },
+                "roles": [
+                    "admin"
+                ],
+                "swift_objects": {
+                    "containers_per_tenant": 2,
+                    "objects_per_container": 5,
+                    "object_size": 10240
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  c2128a0a-072e-47bf-9cc2-6c29841481ff: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: c2128a0a-072e-47bf-9cc2-6c29841481ff
+2018-06-28 18:52:37.134 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Starting:  Task validation.
+2018-06-28 18:52:37.141 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Starting:  Task validation of syntax.
+2018-06-28 18:52:37.152 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Completed: Task validation of syntax.
+2018-06-28 18:52:37.153 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Starting:  Task validation of required platforms.
+2018-06-28 18:52:37.158 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Completed: Task validation of required platforms.
+2018-06-28 18:52:37.158 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Starting:  Task validation of semantic.
+2018-06-28 18:52:40.405 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context users@openstack setup()  finished in 2.60 sec
+2018-06-28 18:52:40.855 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context users@openstack cleanup() started
+2018-06-28 18:52:44.191 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context users@openstack cleanup() finished in 3.34 sec
+2018-06-28 18:52:44.192 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Completed: Task validation of semantic.
+2018-06-28 18:52:44.192 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Completed: Task validation.
+2018-06-28 18:52:44.192 6097 INFO rally.api [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff input file is valid.
+2018-06-28 18:52:44.193 6097 INFO rally.api [-] Run Task c2128a0a-072e-47bf-9cc2-6c29841481ff against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 18:52:44.193 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Starting:  Running task.
+2018-06-28 18:52:44.236 6097 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=70d61caf-b197-4aa7-a435-150b6acbf489)", 
+   "subtasks": [
+      {
+         "title": "SwiftObjects.list_and_download_objects_in_containers", 
+         "description": "List and download objects in all containers.", 
+         "scenario": {
+            "SwiftObjects.list_and_download_objects_in_containers": {}
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 1, 
+               "users_per_tenant": 1
+            }, 
+            "roles": [
+               "admin"
+            ], 
+            "swift_objects": {
+               "containers_per_tenant": 2, 
+               "objects_per_container": 5, 
+               "object_size": 10240
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 2, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 18:52:46.627 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context users@openstack setup()  finished in 2.36 sec
+2018-06-28 18:52:49.337 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context roles@openstack setup()  finished in 2.71 sec
+2018-06-28 18:52:50.654 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context swift_objects@openstack setup()  finished in 1.32 sec
+2018-06-28 18:52:50.678 6315 INFO rally.task.runner [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | ITER: 1 START
+2018-06-28 18:52:50.681 6316 INFO rally.task.runner [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | ITER: 2 START
+2018-06-28 18:52:51.246 6315 INFO rally.task.runner [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | ITER: 1 END: OK
+2018-06-28 18:52:51.311 6316 INFO rally.task.runner [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | ITER: 2 END: OK
+2018-06-28 18:52:51.333 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context swift_objects@openstack cleanup() started
+2018-06-28 18:52:52.522 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context swift_objects@openstack cleanup() finished in 1.19 sec
+2018-06-28 18:52:52.522 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context roles@openstack cleanup() started
+2018-06-28 18:52:53.585 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context roles@openstack cleanup() finished in 1.06 sec
+2018-06-28 18:52:53.586 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context users@openstack cleanup() started
+2018-06-28 18:52:56.954 6097 INFO rally.task.context [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Context users@openstack cleanup() finished in 3.37 sec
+2018-06-28 18:52:58.343 6097 INFO rally.task.engine [-] Load duration is: 0.6315
+2018-06-28 18:52:58.344 6097 INFO rally.task.engine [-] Full runner duration is: 0.672353
+2018-06-28 18:52:58.344 6097 INFO rally.task.engine [-] Full duration is: 12.710419
+2018-06-28 18:52:58.410 6097 INFO rally.task.engine [-] Task c2128a0a-072e-47bf-9cc2-6c29841481ff | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task c2128a0a-072e-47bf-9cc2-6c29841481ff: finished
+--------------------------------------------------------------------------------
+
+test scenario SwiftObjects.list_and_download_objects_in_containers
+args position 0
+args values:
+{
+  "runner": {
+    "times": 2, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 1, 
+      "users_per_tenant": 1
+    }, 
+    "roles": [
+      "admin"
+    ], 
+    "swift_objects": {
+      "containers_per_tenant": 2, 
+      "objects_per_container": 5, 
+      "object_size": 10240
+    }
+  }, 
+  "args": {}, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task c2128a0a-072e-47bf-9cc2-6c29841481ff has 0 error(s)
+--------------------------------------------------------------------------------
+
++--------------------------------------------------------------------------------------------------------------------------------+
+|                                                      Response Times (sec)                                                      |
++-----------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                      | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-----------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| swift.list_containers       | 0.468     | 0.505        | 0.534        | 0.538        | 0.542     | 0.505     | 100.0%  | 2     |
+| swift.list_objects (x2)     | 0.032     | 0.032        | 0.032        | 0.032        | 0.033     | 0.032     | 100.0%  | 2     |
+| swift.download_object (x10) | 0.055     | 0.06         | 0.065        | 0.065        | 0.066     | 0.06      | 100.0%  | 2     |
+| total                       | 0.567     | 0.598        | 0.622        | 0.625        | 0.629     | 0.598     | 100.0%  | 2     |
+|  -> duration                | 0.567     | 0.598        | 0.622        | 0.625        | 0.629     | 0.598     | 100.0%  | 2     |
+|  -> idle_duration           | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 2     |
++-----------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 0.6315
+Full duration: 12.710419
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report c2128a0a-072e-47bf-9cc2-6c29841481ff --out output.html
+
+* To generate a JUnit report, run:
+	rally task export c2128a0a-072e-47bf-9cc2-6c29841481ff --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report c2128a0a-072e-47bf-9cc2-6c29841481ff --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+  "NovaFlavors.create_flavor": [
+    {
+      "runner": {
+        "type": "constant",
+        "concurrency": 5,
+        "times": 20
+      },
+      "args": {
+        "ram": 500,
+        "vcpus" : 1,
+        "disk": 1
+      },
+      "sla": {
+        "failure_rate": {
+          "max": 0
+        }
+      }
+    }
+  ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1
+2018-06-28 18:53:00.305 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Starting:  Task validation.
+2018-06-28 18:53:00.317 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Starting:  Task validation of syntax.
+2018-06-28 18:53:00.330 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Completed: Task validation of syntax.
+2018-06-28 18:53:00.330 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Starting:  Task validation of required platforms.
+2018-06-28 18:53:00.337 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Completed: Task validation of required platforms.
+2018-06-28 18:53:00.337 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Starting:  Task validation of semantic.
+2018-06-28 18:53:03.321 6454 INFO rally.task.context [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Context users@openstack setup()  finished in 2.31 sec
+2018-06-28 18:53:03.764 6454 INFO rally.task.context [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Context users@openstack cleanup() started
+2018-06-28 18:53:07.340 6454 INFO rally.task.context [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Context users@openstack cleanup() finished in 3.58 sec
+2018-06-28 18:53:07.341 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Completed: Task validation of semantic.
+2018-06-28 18:53:07.341 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Completed: Task validation.
+2018-06-28 18:53:07.342 6454 INFO rally.api [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 input file is valid.
+2018-06-28 18:53:07.342 6454 INFO rally.api [-] Run Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 18:53:07.342 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Starting:  Running task.
+2018-06-28 18:53:07.394 6454 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=5126e3ae-18e8-48d3-98da-0b85b275af09)", 
+   "subtasks": [
+      {
+         "title": "NovaFlavors.create_flavor", 
+         "description": "Create a flavor.", 
+         "scenario": {
+            "NovaFlavors.create_flavor": {
+               "ram": 500, 
+               "vcpus": 1, 
+               "disk": 1
+            }
+         }, 
+         "contexts": {}, 
+         "runner": {
+            "constant": {
+               "concurrency": 5, 
+               "times": 20
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 18:53:09.983 6454 INFO rally.task.context [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Context users@openstack setup()  finished in 2.56 sec
+2018-06-28 18:53:09.984 6454 INFO rally.task.context [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Context admin_cleanup@openstack setup()  finished in 0.02 msec
+2018-06-28 18:53:10.007 6582 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 1 START
+2018-06-28 18:53:10.010 6583 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 2 START
+2018-06-28 18:53:10.012 6584 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 3 START
+2018-06-28 18:53:10.019 6590 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 5 START
+2018-06-28 18:53:10.019 6587 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 4 START
+2018-06-28 18:53:10.622 6582 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 1 END: OK
+2018-06-28 18:53:10.622 6590 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 5 END: OK
+2018-06-28 18:53:10.625 6590 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 6 START
+2018-06-28 18:53:10.626 6582 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 7 START
+2018-06-28 18:53:10.637 6583 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 2 END: OK
+2018-06-28 18:53:10.640 6583 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 8 START
+2018-06-28 18:53:10.667 6584 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 3 END: OK
+2018-06-28 18:53:10.671 6584 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 9 START
+2018-06-28 18:53:10.679 6587 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 4 END: OK
+2018-06-28 18:53:10.682 6587 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 10 START
+2018-06-28 18:53:11.066 6590 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 6 END: OK
+2018-06-28 18:53:11.069 6590 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 11 START
+2018-06-28 18:53:11.124 6583 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 8 END: OK
+2018-06-28 18:53:11.126 6583 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 12 START
+2018-06-28 18:53:11.154 6584 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 9 END: OK
+2018-06-28 18:53:11.156 6584 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 13 START
+2018-06-28 18:53:11.160 6587 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 10 END: OK
+2018-06-28 18:53:11.162 6587 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 14 START
+2018-06-28 18:53:11.173 6582 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 7 END: OK
+2018-06-28 18:53:11.175 6582 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 15 START
+2018-06-28 18:53:11.521 6590 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 11 END: OK
+2018-06-28 18:53:11.524 6590 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 16 START
+2018-06-28 18:53:11.608 6583 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 12 END: OK
+2018-06-28 18:53:11.612 6583 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 17 START
+2018-06-28 18:53:11.627 6584 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 13 END: OK
+2018-06-28 18:53:11.629 6584 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 18 START
+2018-06-28 18:53:11.650 6582 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 15 END: OK
+2018-06-28 18:53:11.652 6582 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 19 START
+2018-06-28 18:53:11.709 6587 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 14 END: OK
+2018-06-28 18:53:11.712 6587 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 20 START
+2018-06-28 18:53:11.978 6590 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 16 END: OK
+2018-06-28 18:53:12.056 6583 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 17 END: OK
+2018-06-28 18:53:12.085 6584 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 18 END: OK
+2018-06-28 18:53:12.174 6587 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 20 END: OK
+2018-06-28 18:53:12.203 6582 INFO rally.task.runner [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | ITER: 19 END: OK
+2018-06-28 18:53:12.227 6454 INFO rally.task.context [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Context admin_cleanup@openstack cleanup() started
+2018-06-28 18:53:16.356 6454 INFO rally.task.context [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Context admin_cleanup@openstack cleanup() finished in 4.13 sec
+2018-06-28 18:53:16.357 6454 INFO rally.task.context [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Context users@openstack cleanup() started
+2018-06-28 18:53:20.067 6454 INFO rally.task.context [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Context users@openstack cleanup() finished in 3.71 sec
+2018-06-28 18:53:21.518 6454 INFO rally.task.engine [-] Load duration is: 2.192614
+2018-06-28 18:53:21.518 6454 INFO rally.task.engine [-] Full runner duration is: 2.236028
+2018-06-28 18:53:21.518 6454 INFO rally.task.engine [-] Full duration is: 12.665645
+2018-06-28 18:53:21.598 6454 INFO rally.task.engine [-] Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaFlavors.create_flavor
+args position 0
+args values:
+{
+  "runner": {
+    "concurrency": 5, 
+    "times": 20
+  }, 
+  "contexts": {}, 
+  "args": {
+    "ram": 500, 
+    "vcpus": 1, 
+    "disk": 1
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 has 0 error(s)
+--------------------------------------------------------------------------------
+
++-----------------------------------------------------------------------------------------------------------------------+
+|                                                 Response Times (sec)                                                  |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action             | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.create_flavor | 0.44      | 0.482        | 0.626        | 0.652        | 0.658     | 0.518     | 100.0%  | 20    |
+| total              | 0.44      | 0.482        | 0.626        | 0.652        | 0.658     | 0.518     | 100.0%  | 20    |
+|  -> duration       | 0.44      | 0.482        | 0.626        | 0.652        | 0.658     | 0.518     | 100.0%  | 20    |
+|  -> idle_duration  | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 20    |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 2.192614
+Full duration: 12.665645
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 2f1b5d7b-c13d-42b4-993c-cea18c3dbfa1 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NovaServers.boot_and_delete_server": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "image": {
+                    "name": "Ubuntu 16.04"
+                },
+                "force_delete": false
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        },
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "image": {
+                    "name": "Ubuntu 16.04"
+                },
+                "auto_assign_nic": true
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 2
+                },
+                "network": {
+                    "start_cidr": "192.168.74.0/24",
+                    "networks_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  d6d5a692-3069-41be-8b05-941938ed3e4a: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: d6d5a692-3069-41be-8b05-941938ed3e4a
+2018-06-28 18:53:23.434 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Starting:  Task validation.
+2018-06-28 18:53:23.444 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Starting:  Task validation of syntax.
+2018-06-28 18:53:23.476 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Completed: Task validation of syntax.
+2018-06-28 18:53:23.476 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Starting:  Task validation of required platforms.
+2018-06-28 18:53:23.490 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Completed: Task validation of required platforms.
+2018-06-28 18:53:23.490 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Starting:  Task validation of semantic.
+2018-06-28 18:53:26.439 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context users@openstack setup()  finished in 2.30 sec
+2018-06-28 18:53:28.953 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context users@openstack cleanup() started
+2018-06-28 18:53:32.341 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context users@openstack cleanup() finished in 3.39 sec
+2018-06-28 18:53:32.341 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Completed: Task validation of semantic.
+2018-06-28 18:53:32.341 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Completed: Task validation.
+2018-06-28 18:53:32.342 6718 INFO rally.api [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a input file is valid.
+2018-06-28 18:53:32.342 6718 INFO rally.api [-] Run Task d6d5a692-3069-41be-8b05-941938ed3e4a against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 18:53:32.343 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Starting:  Running task.
+2018-06-28 18:53:32.389 6718 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=4a8b3dd7-91e6-4706-b6d1-66ba3a67be32)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_and_delete_server", 
+         "description": "Boot and delete a server.", 
+         "scenario": {
+            "NovaServers.boot_and_delete_server": {
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "image": {
+                  "name": "Ubuntu 16.04"
+               }, 
+               "force_delete": false
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 18:53:35.084 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context users@openstack setup()  finished in 2.66 sec
+2018-06-28 18:53:35.085 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-28 18:53:35.879 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 1 START
+2018-06-28 18:53:35.881 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 2 START
+2018-06-28 18:54:08.930 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 2 END: OK
+2018-06-28 18:54:08.936 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 3 START
+2018-06-28 18:54:09.207 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 1 END: OK
+2018-06-28 18:54:09.214 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 4 START
+2018-06-28 18:54:37.124 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 4 END: OK
+2018-06-28 18:54:37.129 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 5 START
+2018-06-28 18:54:39.316 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 3 END: OK
+2018-06-28 18:54:39.320 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 6 START
+2018-06-28 18:55:04.754 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 5 END: OK
+2018-06-28 18:55:04.760 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 7 START
+2018-06-28 18:55:07.537 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 6 END: OK
+2018-06-28 18:55:07.542 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 8 START
+2018-06-28 18:55:30.197 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 7 END: OK
+2018-06-28 18:55:30.202 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 9 START
+2018-06-28 18:55:37.890 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 8 END: OK
+2018-06-28 18:55:37.895 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 10 START
+2018-06-28 18:55:55.318 6846 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 9 END: OK
+2018-06-28 18:56:01.348 6847 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 10 END: OK
+2018-06-28 18:56:01.373 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context cleanup@openstack cleanup() started
+2018-06-28 18:56:07.538 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context cleanup@openstack cleanup() finished in 6.17 sec
+2018-06-28 18:56:07.539 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context users@openstack cleanup() started
+2018-06-28 18:56:12.425 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context users@openstack cleanup() finished in 4.89 sec
+2018-06-28 18:56:13.263 6718 INFO rally.task.engine [-] Load duration is: 144.466974
+2018-06-28 18:56:13.263 6718 INFO rally.task.engine [-] Full runner duration is: 145.513639
+2018-06-28 18:56:13.264 6718 INFO rally.task.engine [-] Full duration is: 160.028709
+2018-06-28 18:56:13.341 6718 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=896b6d7d-2a5e-4496-b10b-107c162d8588)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_and_delete_server", 
+         "description": "Boot and delete a server.", 
+         "scenario": {
+            "NovaServers.boot_and_delete_server": {
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "image": {
+                  "name": "Ubuntu 16.04"
+               }, 
+               "auto_assign_nic": true
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 2
+            }, 
+            "network": {
+               "start_cidr": "192.168.74.0/24", 
+               "networks_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 18:56:16.186 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context users@openstack setup()  finished in 2.81 sec
+2018-06-28 18:56:43.312 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context network@openstack setup()  finished in 27.13 sec
+2018-06-28 18:56:43.313 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context cleanup@openstack setup()  finished in 0.02 msec
+2018-06-28 18:56:44.003 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 1 START
+2018-06-28 18:56:44.005 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 2 START
+2018-06-28 18:57:14.061 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 1 END: OK
+2018-06-28 18:57:14.068 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 3 START
+2018-06-28 18:57:14.166 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 2 END: OK
+2018-06-28 18:57:14.173 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 4 START
+2018-06-28 18:57:41.677 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 3 END: OK
+2018-06-28 18:57:41.683 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 5 START
+2018-06-28 18:57:43.867 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 4 END: OK
+2018-06-28 18:57:43.873 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 6 START
+2018-06-28 18:58:07.034 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 5 END: OK
+2018-06-28 18:58:07.041 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 7 START
+2018-06-28 18:58:14.289 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 6 END: OK
+2018-06-28 18:58:14.295 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 8 START
+2018-06-28 18:58:30.297 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 7 END: OK
+2018-06-28 18:58:30.303 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 9 START
+2018-06-28 18:58:39.673 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 8 END: OK
+2018-06-28 18:58:39.678 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 10 START
+2018-06-28 18:58:53.434 7004 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 9 END: OK
+2018-06-28 18:59:05.002 7005 INFO rally.task.runner [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | ITER: 10 END: OK
+2018-06-28 18:59:05.024 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context cleanup@openstack cleanup() started
+2018-06-28 18:59:11.127 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context cleanup@openstack cleanup() finished in 6.10 sec
+2018-06-28 18:59:11.128 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context network@openstack cleanup() started
+2018-06-28 19:00:03.270 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context network@openstack cleanup() finished in 52.14 sec
+2018-06-28 19:00:03.270 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context users@openstack cleanup() started
+2018-06-28 19:00:08.196 6718 INFO rally.task.context [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Context users@openstack cleanup() finished in 4.93 sec
+2018-06-28 19:00:08.587 6718 INFO rally.task.engine [-] Load duration is: 139.995265
+2018-06-28 19:00:08.587 6718 INFO rally.task.engine [-] Full runner duration is: 141.038008
+2018-06-28 19:00:08.587 6718 INFO rally.task.engine [-] Full duration is: 234.846107
+2018-06-28 19:00:08.647 6718 INFO rally.task.engine [-] Task d6d5a692-3069-41be-8b05-941938ed3e4a | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task d6d5a692-3069-41be-8b05-941938ed3e4a: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_and_delete_server
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "image": {
+      "name": "Ubuntu 16.04"
+    }, 
+    "force_delete": false
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task d6d5a692-3069-41be-8b05-941938ed3e4a has 0 error(s)
+--------------------------------------------------------------------------------
+
++-----------------------------------------------------------------------------------------------------------------------+
+|                                                 Response Times (sec)                                                  |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action             | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server   | 20.904    | 25.453       | 30.46        | 30.588       | 30.716    | 25.703    | 100.0%  | 10    |
+| nova.delete_server | 2.457     | 2.58         | 2.835        | 3.805        | 4.774     | 2.782     | 100.0%  | 10    |
+| total              | 23.452    | 28.062       | 33.075       | 33.2         | 33.326    | 28.485    | 100.0%  | 10    |
+|  -> duration       | 22.452    | 27.062       | 32.075       | 32.2         | 32.326    | 27.485    | 100.0%  | 10    |
+|  -> idle_duration  | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 10    |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 144.466974
+Full duration: 160.028709
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_and_delete_server
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 2
+    }, 
+    "network": {
+      "start_cidr": "192.168.74.0/24", 
+      "networks_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "image": {
+      "name": "Ubuntu 16.04"
+    }, 
+    "auto_assign_nic": true
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task d6d5a692-3069-41be-8b05-941938ed3e4a has 0 error(s)
+--------------------------------------------------------------------------------
+
++-----------------------------------------------------------------------------------------------------------------------+
+|                                                 Response Times (sec)                                                  |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action             | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server   | 20.61     | 23.938       | 27.521       | 27.579       | 27.636    | 24.064    | 100.0%  | 10    |
+| nova.delete_server | 2.5       | 2.529        | 4.707        | 4.754        | 4.8       | 2.972     | 100.0%  | 10    |
+| total              | 23.131    | 26.492       | 30.184       | 30.3         | 30.416    | 27.036    | 100.0%  | 10    |
+|  -> duration       | 22.131    | 25.492       | 29.184       | 29.3         | 29.416    | 26.036    | 100.0%  | 10    |
+|  -> idle_duration  | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 10    |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 139.995265
+Full duration: 234.846107
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report d6d5a692-3069-41be-8b05-941938ed3e4a --out output.html
+
+* To generate a JUnit report, run:
+	rally task export d6d5a692-3069-41be-8b05-941938ed3e4a --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report d6d5a692-3069-41be-8b05-941938ed3e4a --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NovaServers.boot_server_from_volume_snapshot": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "image": {
+                    "name": "Ubuntu 14.04 LTS"
+                },
+                "volume_size": 50,
+                "volume_type": ""
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  3299173a-8a95-4d68-b4b6-de20e9c627c7: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 3299173a-8a95-4d68-b4b6-de20e9c627c7
+2018-06-28 19:00:10.502 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Starting:  Task validation.
+2018-06-28 19:00:10.513 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Starting:  Task validation of syntax.
+2018-06-28 19:00:10.529 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Completed: Task validation of syntax.
+2018-06-28 19:00:10.530 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Starting:  Task validation of required platforms.
+2018-06-28 19:00:10.537 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Completed: Task validation of required platforms.
+2018-06-28 19:00:10.537 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Starting:  Task validation of semantic.
+2018-06-28 19:00:13.638 7121 INFO rally.task.context [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Context users@openstack setup()  finished in 2.42 sec
+2018-06-28 19:00:15.165 7121 INFO rally.task.context [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Context users@openstack cleanup() started
+2018-06-28 19:00:18.308 7121 INFO rally.task.context [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Context users@openstack cleanup() finished in 3.14 sec
+2018-06-28 19:00:18.308 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Completed: Task validation of semantic.
+2018-06-28 19:00:18.308 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Completed: Task validation.
+2018-06-28 19:00:18.309 7121 INFO rally.api [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 input file is valid.
+2018-06-28 19:00:18.309 7121 INFO rally.api [-] Run Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 19:00:18.309 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Starting:  Running task.
+2018-06-28 19:00:18.355 7121 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=6fe52507-e02d-4b4a-8fd2-572f814ea55b)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_server_from_volume_snapshot", 
+         "description": "Boot a server from a snapshot.", 
+         "scenario": {
+            "NovaServers.boot_server_from_volume_snapshot": {
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "image": {
+                  "name": "Ubuntu 14.04 LTS"
+               }, 
+               "volume_size": 50, 
+               "volume_type": ""
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 19:00:21.194 7121 INFO rally.task.context [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Context users@openstack setup()  finished in 2.81 sec
+2018-06-28 19:00:21.195 7121 INFO rally.task.context [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-28 19:00:21.926 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 1 START
+2018-06-28 19:00:21.929 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 2 START
+2018-06-28 19:01:06.828 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 1 END: OK
+2018-06-28 19:01:06.835 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 3 START
+2018-06-28 19:01:07.333 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 2 END: OK
+2018-06-28 19:01:07.340 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 4 START
+2018-06-28 19:01:54.132 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 4 END: OK
+2018-06-28 19:01:54.137 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 5 START
+2018-06-28 19:01:56.718 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 3 END: OK
+2018-06-28 19:01:56.723 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 6 START
+2018-06-28 19:02:35.037 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 5 END: OK
+2018-06-28 19:02:35.043 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 7 START
+2018-06-28 19:02:39.463 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 6 END: OK
+2018-06-28 19:02:39.467 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 8 START
+2018-06-28 19:03:13.195 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 7 END: OK
+2018-06-28 19:03:13.201 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 9 START
+2018-06-28 19:03:17.444 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 8 END: OK
+2018-06-28 19:03:17.449 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 10 START
+2018-06-28 19:03:49.402 7250 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 9 END: OK
+2018-06-28 19:03:55.652 7249 INFO rally.task.runner [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | ITER: 10 END: OK
+2018-06-28 19:03:55.674 7121 INFO rally.task.context [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Context cleanup@openstack cleanup() started
+2018-06-28 19:04:22.702 7121 INFO rally.task.context [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Context cleanup@openstack cleanup() finished in 27.03 sec
+2018-06-28 19:04:22.703 7121 INFO rally.task.context [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Context users@openstack cleanup() started
+2018-06-28 19:04:27.634 7121 INFO rally.task.context [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Context users@openstack cleanup() finished in 4.93 sec
+2018-06-28 19:04:27.714 7121 INFO rally.task.engine [-] Load duration is: 212.721957
+2018-06-28 19:04:27.714 7121 INFO rally.task.engine [-] Full runner duration is: 213.766745
+2018-06-28 19:04:27.715 7121 INFO rally.task.engine [-] Full duration is: 249.270842
+2018-06-28 19:04:27.785 7121 INFO rally.task.engine [-] Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 3299173a-8a95-4d68-b4b6-de20e9c627c7: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_server_from_volume_snapshot
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "image": {
+      "name": "Ubuntu 14.04 LTS"
+    }, 
+    "volume_size": 50, 
+    "volume_type": ""
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 3299173a-8a95-4d68-b4b6-de20e9c627c7 has 0 error(s)
+--------------------------------------------------------------------------------
+
++------------------------------------------------------------------------------------------------------------------------------+
+|                                                     Response Times (sec)                                                     |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                    | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume   | 15.663    | 18.929       | 24.303       | 24.359       | 24.415    | 20.185    | 100.0%  | 10    |
+| cinder_v2.create_snapshot | 2.238     | 2.299        | 4.592        | 4.751        | 4.909     | 2.784     | 100.0%  | 10    |
+| nova.boot_server          | 17.941    | 18.289       | 20.824       | 20.873       | 20.921    | 19.143    | 100.0%  | 10    |
+| total                     | 36.199    | 41.817       | 47.099       | 48.49        | 49.88     | 42.112    | 100.0%  | 10    |
+|  -> duration              | 35.199    | 40.817       | 46.099       | 47.49        | 48.88     | 41.112    | 100.0%  | 10    |
+|  -> idle_duration         | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 10    |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 212.721957
+Full duration: 249.270842
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 3299173a-8a95-4d68-b4b6-de20e9c627c7 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 3299173a-8a95-4d68-b4b6-de20e9c627c7 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 3299173a-8a95-4d68-b4b6-de20e9c627c7 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "CinderVolumes.create_and_restore_volume_backup": [
+        {
+            "args": {
+                "size": 20,
+                "do_delete": true,
+                "create_volume_kwargs": {},
+                "create_backup_kwargs": {}
+            },
+            "runner": {
+                "type": "constant",
+                "times": 2,
+                "concurrency": 1
+            },
+            "context": {
+                "users": {
+                    "tenants": 1,
+                    "users_per_tenant": 1
+                },
+                "roles": ["Member"]
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  aad75625-c670-4a34-a2a9-80727791dbb8: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: aad75625-c670-4a34-a2a9-80727791dbb8
+2018-06-28 19:04:29.550 7446 INFO rally.task.engine [-] Task aad75625-c670-4a34-a2a9-80727791dbb8 | Starting:  Task validation.
+2018-06-28 19:04:29.561 7446 INFO rally.task.engine [-] Task aad75625-c670-4a34-a2a9-80727791dbb8 | Starting:  Task validation of syntax.
+2018-06-28 19:04:29.579 7446 INFO rally.task.engine [-] Task aad75625-c670-4a34-a2a9-80727791dbb8 | Completed: Task validation of syntax.
+2018-06-28 19:04:29.579 7446 INFO rally.task.engine [-] Task aad75625-c670-4a34-a2a9-80727791dbb8 | Starting:  Task validation of required platforms.
+2018-06-28 19:04:29.587 7446 INFO rally.task.engine [-] Task aad75625-c670-4a34-a2a9-80727791dbb8 | Completed: Task validation of required platforms.
+2018-06-28 19:04:29.587 7446 INFO rally.task.engine [-] Task aad75625-c670-4a34-a2a9-80727791dbb8 | Starting:  Task validation of semantic.
+2018-06-28 19:04:32.592 7446 INFO rally.task.context [-] Task aad75625-c670-4a34-a2a9-80727791dbb8 | Context users@openstack setup()  finished in 2.36 sec
+2018-06-28 19:04:33.590 7446 INFO rally.task.context [-] Task aad75625-c670-4a34-a2a9-80727791dbb8 | Context users@openstack cleanup() started
+2018-06-28 19:04:36.824 7446 INFO rally.task.context [-] Task aad75625-c670-4a34-a2a9-80727791dbb8 | Context users@openstack cleanup() finished in 3.23 sec
+Task config is invalid: `Input task is invalid!
+
+Subtask CinderVolumes.create_and_restore_volume_backup[0] has wrong configuration
+Subtask configuration:
+{"version": 2, "title": "A cropped version of a bigger task.", "description": "Auto-generated task from a single workload", "subtasks": [{"title": "CinderVolumes.create_and_restore_volume_backup", "description": "Restore volume backup.", "scenario": {"CinderVolumes.create_and_restore_volume_backup": {"size": 20, "do_delete": true, "create_volume_kwargs": {}, "create_backup_kwargs": {}}}, "contexts": {"users": {"tenants": 1, "users_per_tenant": 1}, "roles": ["Member"]}, "runner": {"constant": {"times": 2, "concurrency": 1}}, "hooks": [], "sla": {"failure_rate": {"max": 0}}}]}
+
+Reason(s):
+ cinder-backup service is not available`
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NovaServers.resize_server": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.small"
+                },
+                "image": {
+                    "name": "CentOS 7"
+                },
+                "to_flavor": {
+                    "name": "m1.large"
+                },
+                "confirm": true,
+                "force_delete": false
+            },
+            "runner": {
+                "type": "constant",
+                "times": 20,
+                "concurrency": 5
+            },
+            "context": {
+                "users": {
+                    "tenants": 1,
+                    "users_per_tenant": 1
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  67c7943a-cdc3-4c64-a95c-981ce3c32c8b: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 67c7943a-cdc3-4c64-a95c-981ce3c32c8b
+2018-06-28 19:04:38.578 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Starting:  Task validation.
+2018-06-28 19:04:38.589 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Starting:  Task validation of syntax.
+2018-06-28 19:04:38.605 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Completed: Task validation of syntax.
+2018-06-28 19:04:38.605 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Starting:  Task validation of required platforms.
+2018-06-28 19:04:38.612 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Completed: Task validation of required platforms.
+2018-06-28 19:04:38.613 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Starting:  Task validation of semantic.
+2018-06-28 19:04:41.866 7533 INFO rally.task.context [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Context users@openstack setup()  finished in 2.48 sec
+2018-06-28 19:04:43.287 7533 INFO rally.task.context [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Context users@openstack cleanup() started
+2018-06-28 19:04:46.687 7533 INFO rally.task.context [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Context users@openstack cleanup() finished in 3.40 sec
+2018-06-28 19:04:46.687 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Completed: Task validation of semantic.
+2018-06-28 19:04:46.688 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Completed: Task validation.
+2018-06-28 19:04:46.688 7533 INFO rally.api [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b input file is valid.
+2018-06-28 19:04:46.689 7533 INFO rally.api [-] Run Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 19:04:46.689 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Starting:  Running task.
+2018-06-28 19:04:46.748 7533 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=4b94f84b-f180-4fd8-9b9c-7fa1d624741d)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.resize_server", 
+         "description": "Boot a server, then resize and delete it.", 
+         "scenario": {
+            "NovaServers.resize_server": {
+               "flavor": {
+                  "name": "m1.small"
+               }, 
+               "image": {
+                  "name": "CentOS 7"
+               }, 
+               "to_flavor": {
+                  "name": "m1.large"
+               }, 
+               "confirm": true, 
+               "force_delete": false
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 1, 
+               "users_per_tenant": 1
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 20, 
+               "concurrency": 5
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 19:04:49.384 7533 INFO rally.task.context [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Context users@openstack setup()  finished in 2.60 sec
+2018-06-28 19:04:49.385 7533 INFO rally.task.context [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Context cleanup@openstack setup()  finished in 0.04 msec
+2018-06-28 19:04:50.215 7661 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 1 START
+2018-06-28 19:04:50.220 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 2 START
+2018-06-28 19:04:50.221 7663 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 3 START
+2018-06-28 19:04:50.224 7664 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 4 START
+2018-06-28 19:04:50.228 7667 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 5 START
+2018-06-28 19:06:06.134 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 2 END: OK
+2018-06-28 19:06:06.140 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 6 START
+2018-06-28 19:06:13.472 7664 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 4 END: OK
+2018-06-28 19:06:13.479 7664 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 7 START
+2018-06-28 19:06:13.682 7667 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 5 END: OK
+2018-06-28 19:06:13.685 7663 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 3 END: OK
+2018-06-28 19:06:13.687 7667 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 8 START
+2018-06-28 19:06:13.691 7663 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 9 START
+2018-06-28 19:06:15.614 7661 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 1 END: OK
+2018-06-28 19:06:15.619 7661 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 10 START
+2018-06-28 19:06:55.427 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 6 END: OK
+2018-06-28 19:06:55.431 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 11 START
+2018-06-28 19:07:11.085 7663 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 9 END: OK
+2018-06-28 19:07:11.090 7663 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 12 START
+2018-06-28 19:07:18.848 7667 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 8 END: OK
+2018-06-28 19:07:18.854 7667 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 13 START
+2018-06-28 19:07:22.093 7661 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 10 END: OK
+2018-06-28 19:07:22.097 7661 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 14 START
+2018-06-28 19:07:27.955 7664 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 7 END: OK
+2018-06-28 19:07:27.960 7664 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 15 START
+2018-06-28 19:07:47.864 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 11 END: OK
+2018-06-28 19:07:47.869 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 16 START
+2018-06-28 19:07:57.670 7663 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 12 END: OK
+2018-06-28 19:07:57.674 7663 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 17 START
+2018-06-28 19:08:13.865 7664 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 15 END: OK
+2018-06-28 19:08:13.869 7664 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 18 START
+2018-06-28 19:08:15.131 7667 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 13 END: OK
+2018-06-28 19:08:15.135 7667 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 19 START
+2018-06-28 19:08:34.423 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 16 END: OK
+2018-06-28 19:08:34.428 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 20 START
+2018-06-28 19:08:36.826 7661 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 14 END: OK
+2018-06-28 19:08:41.285 7663 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 17 END: OK
+2018-06-28 19:09:15.884 7662 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 20 END: OK
+2018-06-28 19:09:19.187 7667 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 19 END: OK
+2018-06-28 19:09:23.513 7664 INFO rally.task.runner [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | ITER: 18 END: OK
+2018-06-28 19:09:23.542 7533 INFO rally.task.context [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Context cleanup@openstack cleanup() started
+2018-06-28 19:09:25.073 7533 INFO rally.task.context [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Context cleanup@openstack cleanup() finished in 1.53 sec
+2018-06-28 19:09:25.073 7533 INFO rally.task.context [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Context users@openstack cleanup() started
+2018-06-28 19:09:28.067 7533 INFO rally.task.context [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Context users@openstack cleanup() finished in 2.99 sec
+2018-06-28 19:09:28.231 7533 INFO rally.task.engine [-] Load duration is: 272.295109
+2018-06-28 19:09:28.232 7533 INFO rally.task.engine [-] Full runner duration is: 273.343701
+2018-06-28 19:09:28.232 7533 INFO rally.task.engine [-] Full duration is: 281.307953
+2018-06-28 19:09:28.310 7533 INFO rally.task.engine [-] Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.resize_server
+args position 0
+args values:
+{
+  "runner": {
+    "times": 20, 
+    "concurrency": 5
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 1, 
+      "users_per_tenant": 1
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.small"
+    }, 
+    "image": {
+      "name": "CentOS 7"
+    }, 
+    "to_flavor": {
+      "name": "m1.large"
+    }, 
+    "confirm": true, 
+    "force_delete": false
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 67c7943a-cdc3-4c64-a95c-981ce3c32c8b has 0 error(s)
+--------------------------------------------------------------------------------
+
++------------------------------------------------------------------------------------------------------------------------+
+|                                                  Response Times (sec)                                                  |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action              | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server    | 13.576    | 20.531       | 50.173       | 50.203       | 50.293    | 27.721    | 100.0%  | 20    |
+| nova.resize         | 22.427    | 27.817       | 39.002       | 44.142       | 49.09     | 29.434    | 100.0%  | 20    |
+| nova.resize_confirm | 2.576     | 2.672        | 3.103        | 4.912        | 4.918     | 2.921     | 100.0%  | 20    |
+| nova.delete_server  | 2.462     | 2.586        | 4.706        | 4.748        | 4.871     | 3.197     | 100.0%  | 20    |
+| total               | 41.455    | 64.605       | 83.452       | 83.558       | 85.396    | 63.274    | 100.0%  | 20    |
+|  -> duration        | 40.455    | 63.605       | 82.452       | 82.558       | 84.396    | 62.274    | 100.0%  | 20    |
+|  -> idle_duration   | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 20    |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 272.295109
+Full duration: 281.307953
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 67c7943a-cdc3-4c64-a95c-981ce3c32c8b --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 67c7943a-cdc3-4c64-a95c-981ce3c32c8b --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 67c7943a-cdc3-4c64-a95c-981ce3c32c8b --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NovaServers.boot_server_from_volume_and_resize": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.small"
+                },
+                "image": {
+                    "name": "CentOS 7"
+                },
+                "to_flavor": {
+                    "name": "m1.medium"
+                },
+                "confirm": true,
+                "volume_size": 20,
+                "force_delete": false,
+                "do_delete": true,
+                "boot_server_kwargs": {},
+                "create_volume_kwargs": {}
+            },
+            "runner": {
+                "type": "constant",
+                "times": 50,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  dae17851-63d5-4595-a606-24ee613e4559: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: dae17851-63d5-4595-a606-24ee613e4559
+2018-06-28 19:09:30.101 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Starting:  Task validation.
+2018-06-28 19:09:30.108 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Starting:  Task validation of syntax.
+2018-06-28 19:09:30.118 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Completed: Task validation of syntax.
+2018-06-28 19:09:30.118 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Starting:  Task validation of required platforms.
+2018-06-28 19:09:30.123 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Completed: Task validation of required platforms.
+2018-06-28 19:09:30.123 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Starting:  Task validation of semantic.
+2018-06-28 19:09:33.010 7797 INFO rally.task.context [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Context users@openstack setup()  finished in 2.28 sec
+2018-06-28 19:09:34.317 7797 INFO rally.task.context [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Context users@openstack cleanup() started
+2018-06-28 19:09:37.909 7797 INFO rally.task.context [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Context users@openstack cleanup() finished in 3.59 sec
+2018-06-28 19:09:37.910 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Completed: Task validation of semantic.
+2018-06-28 19:09:37.911 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Completed: Task validation.
+2018-06-28 19:09:37.911 7797 INFO rally.api [-] Task dae17851-63d5-4595-a606-24ee613e4559 input file is valid.
+2018-06-28 19:09:37.912 7797 INFO rally.api [-] Run Task dae17851-63d5-4595-a606-24ee613e4559 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 19:09:37.912 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Starting:  Running task.
+2018-06-28 19:09:37.972 7797 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=62350eeb-50ec-44ca-9b85-f1c100637a0b)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_server_from_volume_and_resize", 
+         "description": "Boot a server from volume, then resize and delete it.", 
+         "scenario": {
+            "NovaServers.boot_server_from_volume_and_resize": {
+               "flavor": {
+                  "name": "m1.small"
+               }, 
+               "image": {
+                  "name": "CentOS 7"
+               }, 
+               "to_flavor": {
+                  "name": "m1.medium"
+               }, 
+               "confirm": true, 
+               "volume_size": 20, 
+               "force_delete": false, 
+               "do_delete": true, 
+               "boot_server_kwargs": {}, 
+               "create_volume_kwargs": {}
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 50, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 19:09:40.751 7797 INFO rally.task.context [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Context users@openstack setup()  finished in 2.74 sec
+2018-06-28 19:09:40.752 7797 INFO rally.task.context [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Context cleanup@openstack setup()  finished in 0.02 msec
+2018-06-28 19:09:41.651 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 1 START
+2018-06-28 19:09:41.654 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 2 START
+2018-06-28 19:11:57.470 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 1 END: OK
+2018-06-28 19:11:57.477 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 3 START
+2018-06-28 19:11:57.776 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 2 END: OK
+2018-06-28 19:11:57.784 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 4 START
+2018-06-28 19:14:08.398 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 4 END: OK
+2018-06-28 19:14:08.403 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 5 START
+2018-06-28 19:14:21.247 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 3 END: OK
+2018-06-28 19:14:21.253 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 6 START
+2018-06-28 19:16:00.221 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 5 END: OK
+2018-06-28 19:16:00.227 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 7 START
+2018-06-28 19:17:47.853 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 7 END: OK
+2018-06-28 19:17:47.859 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 8 START
+2018-06-28 19:19:35.605 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 8 END: OK
+2018-06-28 19:19:35.609 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 9 START
+2018-06-28 19:21:23.462 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 9 END: OK
+2018-06-28 19:21:23.467 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 10 START
+2018-06-28 19:23:10.568 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 10 END: OK
+2018-06-28 19:23:10.573 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 11 START
+2018-06-28 19:24:25.515 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 6 END: Error TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_62350eeb_J0eJlgpb:b4106bd6-7e1d-4b25-9d80-efa4c6bd2709 to become ('AVAILABLE') current status ERROR
+2018-06-28 19:24:25.521 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 12 START
+2018-06-28 19:24:57.901 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 11 END: OK
+2018-06-28 19:24:57.907 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 13 START
+2018-06-28 19:26:12.448 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 12 END: OK
+2018-06-28 19:26:12.454 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 14 START
+2018-06-28 19:26:50.051 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 13 END: OK
+2018-06-28 19:26:50.056 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 15 START
+2018-06-28 19:27:59.116 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 14 END: OK
+2018-06-28 19:27:59.122 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 16 START
+2018-06-28 19:28:37.085 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 15 END: OK
+2018-06-28 19:28:37.090 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 17 START
+2018-06-28 19:29:51.524 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 16 END: OK
+2018-06-28 19:29:51.529 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 18 START
+2018-06-28 19:30:28.973 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 17 END: OK
+2018-06-28 19:30:28.977 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 19 START
+2018-06-28 19:31:38.306 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 18 END: OK
+2018-06-28 19:31:38.310 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 20 START
+2018-06-28 19:32:15.543 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 19 END: OK
+2018-06-28 19:32:15.547 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 21 START
+2018-06-28 19:33:30.309 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 20 END: OK
+2018-06-28 19:33:30.315 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 22 START
+2018-06-28 19:34:02.433 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 21 END: OK
+2018-06-28 19:34:02.438 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 23 START
+2018-06-28 19:35:17.294 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 22 END: OK
+2018-06-28 19:35:17.298 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 24 START
+2018-06-28 19:35:54.680 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 23 END: OK
+2018-06-28 19:35:54.685 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 25 START
+2018-06-28 19:37:04.151 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 24 END: OK
+2018-06-28 19:37:04.157 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 26 START
+2018-06-28 19:37:48.817 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 25 END: OK
+2018-06-28 19:37:48.822 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 27 START
+2018-06-28 19:38:56.790 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 26 END: OK
+2018-06-28 19:38:56.794 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 28 START
+2018-06-28 19:39:35.559 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 27 END: OK
+2018-06-28 19:39:35.564 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 29 START
+2018-06-28 19:40:43.622 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 28 END: OK
+2018-06-28 19:40:43.626 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 30 START
+2018-06-28 19:41:22.313 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 29 END: OK
+2018-06-28 19:41:22.317 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 31 START
+2018-06-28 19:42:28.370 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 30 END: OK
+2018-06-28 19:42:28.376 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 32 START
+2018-06-28 19:43:11.542 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 31 END: OK
+2018-06-28 19:43:11.547 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 33 START
+2018-06-28 19:44:16.163 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 32 END: OK
+2018-06-28 19:44:16.168 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 34 START
+2018-06-28 19:44:57.968 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 33 END: OK
+2018-06-28 19:44:57.973 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 35 START
+2018-06-28 19:46:02.696 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 34 END: OK
+2018-06-28 19:46:02.700 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 36 START
+2018-06-28 19:46:44.910 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 35 END: OK
+2018-06-28 19:46:44.915 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 37 START
+2018-06-28 19:47:49.319 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 36 END: OK
+2018-06-28 19:47:49.325 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 38 START
+2018-06-28 19:48:31.653 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 37 END: OK
+2018-06-28 19:48:31.657 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 39 START
+2018-06-28 19:49:38.749 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 38 END: OK
+2018-06-28 19:49:38.754 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 40 START
+2018-06-28 19:50:21.191 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 39 END: OK
+2018-06-28 19:50:21.196 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 41 START
+2018-06-28 19:51:35.086 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 40 END: OK
+2018-06-28 19:51:35.091 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 42 START
+2018-06-28 19:52:08.068 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 41 END: OK
+2018-06-28 19:52:08.073 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 43 START
+2018-06-28 19:53:26.830 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 42 END: OK
+2018-06-28 19:53:26.834 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 44 START
+2018-06-28 19:53:55.384 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 43 END: OK
+2018-06-28 19:53:55.387 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 45 START
+2018-06-28 19:55:25.806 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 44 END: OK
+2018-06-28 19:55:25.812 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 46 START
+2018-06-28 19:55:49.403 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 45 END: OK
+2018-06-28 19:55:49.407 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 47 START
+2018-06-28 19:57:24.411 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 46 END: OK
+2018-06-28 19:57:24.416 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 48 START
+2018-06-28 19:57:36.464 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 47 END: OK
+2018-06-28 19:57:36.469 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 49 START
+2018-06-28 19:59:15.694 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 48 END: OK
+2018-06-28 19:59:15.699 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 50 START
+2018-06-28 19:59:27.851 7926 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 49 END: OK
+2018-06-28 20:01:09.593 7925 INFO rally.task.runner [-] Task dae17851-63d5-4595-a606-24ee613e4559 | ITER: 50 END: OK
+2018-06-28 20:01:09.621 7797 INFO rally.task.context [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Context cleanup@openstack cleanup() started
+2018-06-28 20:01:24.619 7797 INFO rally.task.context [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Context cleanup@openstack cleanup() finished in 15.00 sec
+2018-06-28 20:01:24.620 7797 INFO rally.task.context [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Context users@openstack cleanup() started
+2018-06-28 20:01:29.489 7797 INFO rally.task.context [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Context users@openstack cleanup() finished in 4.87 sec
+2018-06-28 20:01:29.785 7797 INFO rally.task.engine [-] Load duration is: 3086.935333
+2018-06-28 20:01:29.786 7797 INFO rally.task.engine [-] Full runner duration is: 3087.990269
+2018-06-28 20:01:29.786 7797 INFO rally.task.engine [-] Full duration is: 3111.503021
+2018-06-28 20:01:29.899 7797 INFO rally.task.engine [-] Task dae17851-63d5-4595-a606-24ee613e4559 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task dae17851-63d5-4595-a606-24ee613e4559: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_server_from_volume_and_resize
+args position 0
+args values:
+{
+  "runner": {
+    "times": 50, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.small"
+    }, 
+    "image": {
+      "name": "CentOS 7"
+    }, 
+    "to_flavor": {
+      "name": "m1.medium"
+    }, 
+    "confirm": true, 
+    "volume_size": 20, 
+    "force_delete": false, 
+    "do_delete": true, 
+    "boot_server_kwargs": {}, 
+    "create_volume_kwargs": {}
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task dae17851-63d5-4595-a606-24ee613e4559 has 1 error(s)
+--------------------------------------------------------------------------------
+
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_62350eeb_J0eJlgpb:b4106bd6-7e1d-4b25-9d80-efa4c6bd2709 to become ('AVAILABLE') current status ERROR
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 592, in run
+    **create_volume_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/block.py", line 77, in create_volume
+    source_replica=source_replica, multiattach=multiattach)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 274, in create_volume
+    source_replica=source_replica, multiattach=multiattach))
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 83, in create_volume
+    return self._wait_available_volume(volume)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_common.py", line 56, in _wait_available_volume
+    check_interval=CONF.openstack.cinder_volume_create_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 253, in wait_for_status
+    timeout=timeout)
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_62350eeb_J0eJlgpb:b4106bd6-7e1d-4b25-9d80-efa4c6bd2709 to become ('AVAILABLE') current status ERROR
+
+--------------------------------------------------------------------------------
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume | 19.91     | 22.116       | 28.061       | 47.749       | 604.254   | 36.041    | 98.0%   | 50    |
+| nova.boot_server        | 8.791     | 9.141        | 9.612        | 10.864       | 13.495    | 9.376     | 100.0%  | 49    |
+| nova.resize             | 70.06     | 70.653       | 75.616       | 75.782       | 80.454    | 72.112    | 100.0%  | 49    |
+| nova.resize_confirm     | 2.599     | 2.677        | 2.807        | 2.875        | 3.017     | 2.702     | 100.0%  | 49    |
+| nova.delete_server      | 2.449     | 2.536        | 4.666        | 4.722        | 9.573     | 2.988     | 100.0%  | 49    |
+| total                   | 104.741   | 107.817      | 120.133      | 135.98       | 604.255   | 121.475   | 98.0%   | 50    |
+|  -> duration            | 103.741   | 106.817      | 119.133      | 134.98       | 604.255   | 120.495   | 98.0%   | 50    |
+|  -> idle_duration       | 0.0       | 1.0          | 1.0          | 1.0          | 1.0       | 0.98      | 98.0%   | 50    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 3086.935333
+Full duration: 3111.503021
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report dae17851-63d5-4595-a606-24ee613e4559 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export dae17851-63d5-4595-a606-24ee613e4559 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report dae17851-63d5-4595-a606-24ee613e4559 --json --out output.json
+
+At least one workload did not pass SLA criteria.
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "CinderVolumes.create_and_upload_volume_to_image": [
+        {
+            "args": {
+                "size": 1,
+                "force": false,
+                "container_format": "bare",
+                "disk_format": "raw",
+                "do_delete": true,
+                "image": {
+                    "name": "Cirros-0.3.5"
+                }
+            },
+            "runner": {
+                "type": "constant",
+                "times": 3,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 2,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        },
+        {
+            "args": {
+                "size": {
+                    "min": 1,
+                    "max": 5
+                },
+                "force": false,
+                "container_format": "bare",
+                "disk_format": "raw",
+                "do_delete": true,
+                "image": {
+                    "name": "Cirros-0.3.5"
+                }
+            },
+            "runner": {
+                "type": "constant",
+                "times": 3,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 2,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  e6afbf92-f276-4b99-9d86-81277fafc7bf: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: e6afbf92-f276-4b99-9d86-81277fafc7bf
+2018-06-28 20:01:31.798 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Starting:  Task validation.
+2018-06-28 20:01:31.808 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Starting:  Task validation of syntax.
+2018-06-28 20:01:31.838 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Completed: Task validation of syntax.
+2018-06-28 20:01:31.839 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Starting:  Task validation of required platforms.
+2018-06-28 20:01:31.852 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Completed: Task validation of required platforms.
+2018-06-28 20:01:31.852 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Starting:  Task validation of semantic.
+2018-06-28 20:01:34.816 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context users@openstack setup()  finished in 2.27 sec
+2018-06-28 20:01:35.705 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context users@openstack cleanup() started
+2018-06-28 20:01:39.197 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context users@openstack cleanup() finished in 3.49 sec
+2018-06-28 20:01:39.198 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Completed: Task validation of semantic.
+2018-06-28 20:01:39.198 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Completed: Task validation.
+2018-06-28 20:01:39.199 8201 INFO rally.api [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf input file is valid.
+2018-06-28 20:01:39.199 8201 INFO rally.api [-] Run Task e6afbf92-f276-4b99-9d86-81277fafc7bf against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 20:01:39.199 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Starting:  Running task.
+2018-06-28 20:01:39.253 8201 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=141bb485-5080-44ba-a5a0-63ee26e31c6e)", 
+   "subtasks": [
+      {
+         "title": "CinderVolumes.create_and_upload_volume_to_image", 
+         "description": "Create and upload a volume to image.", 
+         "scenario": {
+            "CinderVolumes.create_and_upload_volume_to_image": {
+               "size": 1, 
+               "force": false, 
+               "container_format": "bare", 
+               "disk_format": "raw", 
+               "do_delete": true, 
+               "image": {
+                  "name": "Cirros-0.3.5"
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 2, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 3, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 20:01:42.034 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context users@openstack setup()  finished in 2.75 sec
+2018-06-28 20:01:42.034 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context cleanup@openstack setup()  finished in 0.10 msec
+2018-06-28 20:01:42.804 8329 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 1 START
+2018-06-28 20:01:42.806 8330 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 2 START
+2018-06-28 20:02:06.637 8330 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 2 END: OK
+2018-06-28 20:02:06.644 8330 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 3 START
+2018-06-28 20:02:06.684 8329 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 1 END: OK
+2018-06-28 20:02:23.993 8330 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 3 END: OK
+2018-06-28 20:02:24.013 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context cleanup@openstack cleanup() started
+2018-06-28 20:02:29.577 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context cleanup@openstack cleanup() finished in 5.56 sec
+2018-06-28 20:02:29.577 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context users@openstack cleanup() started
+2018-06-28 20:02:33.983 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context users@openstack cleanup() finished in 4.41 sec
+2018-06-28 20:02:35.613 8201 INFO rally.task.engine [-] Load duration is: 40.254082
+2018-06-28 20:02:35.614 8201 INFO rally.task.engine [-] Full runner duration is: 41.227913
+2018-06-28 20:02:35.614 8201 INFO rally.task.engine [-] Full duration is: 54.722798
+2018-06-28 20:02:35.696 8201 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=cdfcc28c-122d-4f50-af27-49436d6db55c)", 
+   "subtasks": [
+      {
+         "title": "CinderVolumes.create_and_upload_volume_to_image", 
+         "description": "Create and upload a volume to image.", 
+         "scenario": {
+            "CinderVolumes.create_and_upload_volume_to_image": {
+               "size": {
+                  "min": 1, 
+                  "max": 5
+               }, 
+               "force": false, 
+               "container_format": "bare", 
+               "disk_format": "raw", 
+               "do_delete": true, 
+               "image": {
+                  "name": "Cirros-0.3.5"
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 2, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 3, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 20:02:38.194 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context users@openstack setup()  finished in 2.46 sec
+2018-06-28 20:02:38.195 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context cleanup@openstack setup()  finished in 0.02 msec
+2018-06-28 20:02:38.938 8520 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 1 START
+2018-06-28 20:02:38.941 8521 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 2 START
+2018-06-28 20:03:45.026 8520 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 1 END: OK
+2018-06-28 20:03:45.032 8520 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 3 START
+2018-06-28 20:03:45.195 8521 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 2 END: OK
+2018-06-28 20:04:32.688 8520 INFO rally.task.runner [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | ITER: 3 END: OK
+2018-06-28 20:04:32.712 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context cleanup@openstack cleanup() started
+2018-06-28 20:04:38.063 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context cleanup@openstack cleanup() finished in 5.35 sec
+2018-06-28 20:04:38.064 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context users@openstack cleanup() started
+2018-06-28 20:04:42.036 8201 INFO rally.task.context [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Context users@openstack cleanup() finished in 3.97 sec
+2018-06-28 20:04:42.387 8201 INFO rally.task.engine [-] Load duration is: 112.890758
+2018-06-28 20:04:42.387 8201 INFO rally.task.engine [-] Full runner duration is: 113.791743
+2018-06-28 20:04:42.387 8201 INFO rally.task.engine [-] Full duration is: 126.330169
+2018-06-28 20:04:42.450 8201 INFO rally.task.engine [-] Task e6afbf92-f276-4b99-9d86-81277fafc7bf | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task e6afbf92-f276-4b99-9d86-81277fafc7bf: finished
+--------------------------------------------------------------------------------
+
+test scenario CinderVolumes.create_and_upload_volume_to_image
+args position 0
+args values:
+{
+  "runner": {
+    "times": 3, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 2, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "size": 1, 
+    "force": false, 
+    "container_format": "bare", 
+    "disk_format": "raw", 
+    "do_delete": true, 
+    "image": {
+      "name": "Cirros-0.3.5"
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task e6afbf92-f276-4b99-9d86-81277fafc7bf has 0 error(s)
+--------------------------------------------------------------------------------
+
++-------------------------------------------------------------------------------------------------------------------------------------+
+|                                                        Response Times (sec)                                                         |
++----------------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                           | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++----------------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume          | 4.711     | 4.803        | 4.876        | 4.885        | 4.894     | 4.803     | 100.0%  | 3     |
+| cinder_v2.upload_volume_to_image | 8.758     | 15.097       | 15.12        | 15.123       | 15.125    | 12.993    | 100.0%  | 3     |
+| cinder_v2.delete_volume          | 2.227     | 2.27         | 2.297        | 2.301        | 2.304     | 2.267     | 100.0%  | 3     |
+| glance_v2.delete_image           | 0.666     | 0.737        | 0.753        | 0.755        | 0.757     | 0.72      | 100.0%  | 3     |
+| total                            | 16.525    | 22.899       | 22.923       | 22.926       | 22.929    | 20.784    | 100.0%  | 3     |
+|  -> duration                     | 16.525    | 22.899       | 22.923       | 22.926       | 22.929    | 20.784    | 100.0%  | 3     |
+|  -> idle_duration                | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 3     |
++----------------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 40.254082
+Full duration: 54.722798
+--------------------------------------------------------------------------------
+
+test scenario CinderVolumes.create_and_upload_volume_to_image
+args position 0
+args values:
+{
+  "runner": {
+    "times": 3, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 2, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "size": {
+      "min": 1, 
+      "max": 5
+    }, 
+    "force": false, 
+    "container_format": "bare", 
+    "disk_format": "raw", 
+    "do_delete": true, 
+    "image": {
+      "name": "Cirros-0.3.5"
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task e6afbf92-f276-4b99-9d86-81277fafc7bf has 0 error(s)
+--------------------------------------------------------------------------------
+
++-------------------------------------------------------------------------------------------------------------------------------------+
+|                                                        Response Times (sec)                                                         |
++----------------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                           | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++----------------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume          | 4.737     | 4.847        | 4.87         | 4.873        | 4.876     | 4.82      | 100.0%  | 3     |
+| cinder_v2.upload_volume_to_image | 38.299    | 57.231       | 57.303       | 57.312       | 57.321    | 50.95     | 100.0%  | 3     |
+| cinder_v2.delete_volume          | 2.218     | 2.265        | 2.316        | 2.322        | 2.329     | 2.27      | 100.0%  | 3     |
+| glance_v2.delete_image           | 0.932     | 0.963        | 1.104        | 1.122        | 1.14      | 1.012     | 100.0%  | 3     |
+| total                            | 46.552    | 65.229       | 65.348       | 65.363       | 65.378    | 59.053    | 100.0%  | 3     |
+|  -> duration                     | 46.552    | 65.229       | 65.348       | 65.363       | 65.378    | 59.053    | 100.0%  | 3     |
+|  -> idle_duration                | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 3     |
++----------------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 112.890758
+Full duration: 126.330169
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report e6afbf92-f276-4b99-9d86-81277fafc7bf --out output.html
+
+* To generate a JUnit report, run:
+	rally task export e6afbf92-f276-4b99-9d86-81277fafc7bf --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report e6afbf92-f276-4b99-9d86-81277fafc7bf --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NovaServers.boot_server_attach_created_volume_and_resize": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "image": {
+                    "name": "Ubuntu 14.04 LTS"
+                },
+                "to_flavor": {
+                    "name": "m1.large"
+                },
+                "confirm": true,
+                "volume_size": 1,
+                "force_delete": false,
+                "do_delete": true,
+                "boot_server_kwargs": {},
+                "create_volume_kwargs": {}
+            },
+            "runner": {
+                "type": "constant",
+                "times": 4,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  b786732f-471e-4aa6-91f7-9bcbbb40d3c0: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: b786732f-471e-4aa6-91f7-9bcbbb40d3c0
+2018-06-28 20:04:44.314 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Starting:  Task validation.
+2018-06-28 20:04:44.325 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Starting:  Task validation of syntax.
+2018-06-28 20:04:44.341 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Completed: Task validation of syntax.
+2018-06-28 20:04:44.341 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Starting:  Task validation of required platforms.
+2018-06-28 20:04:44.349 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Completed: Task validation of required platforms.
+2018-06-28 20:04:44.349 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Starting:  Task validation of semantic.
+2018-06-28 20:04:47.527 8670 INFO rally.task.context [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Context users@openstack setup()  finished in 2.48 sec
+2018-06-28 20:04:49.033 8670 INFO rally.task.context [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Context users@openstack cleanup() started
+2018-06-28 20:04:52.378 8670 INFO rally.task.context [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Context users@openstack cleanup() finished in 3.35 sec
+2018-06-28 20:04:52.379 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Completed: Task validation of semantic.
+2018-06-28 20:04:52.379 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Completed: Task validation.
+2018-06-28 20:04:52.380 8670 INFO rally.api [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 input file is valid.
+2018-06-28 20:04:52.380 8670 INFO rally.api [-] Run Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 20:04:52.380 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Starting:  Running task.
+2018-06-28 20:04:52.427 8670 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=e9d228a3-06cc-49ae-a27c-2509dbfa3b40)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_server_attach_created_volume_and_resize", 
+         "description": "Create a VM from image, attach a volume to it and resize.", 
+         "scenario": {
+            "NovaServers.boot_server_attach_created_volume_and_resize": {
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "image": {
+                  "name": "Ubuntu 14.04 LTS"
+               }, 
+               "to_flavor": {
+                  "name": "m1.large"
+               }, 
+               "confirm": true, 
+               "volume_size": 1, 
+               "force_delete": false, 
+               "do_delete": true, 
+               "boot_server_kwargs": {}, 
+               "create_volume_kwargs": {}
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 4, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 20:04:55.236 8670 INFO rally.task.context [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Context users@openstack setup()  finished in 2.78 sec
+2018-06-28 20:04:55.237 8670 INFO rally.task.context [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Context cleanup@openstack setup()  finished in 0.02 msec
+2018-06-28 20:04:55.997 8798 INFO rally.task.runner [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | ITER: 1 START
+2018-06-28 20:04:55.999 8799 INFO rally.task.runner [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | ITER: 2 START
+2018-06-28 20:06:08.757 8799 INFO rally.task.runner [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | ITER: 2 END: OK
+2018-06-28 20:06:08.763 8799 INFO rally.task.runner [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | ITER: 3 START
+2018-06-28 20:06:13.334 8798 INFO rally.task.runner [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | ITER: 1 END: OK
+2018-06-28 20:06:13.339 8798 INFO rally.task.runner [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | ITER: 4 START
+2018-06-28 20:07:15.836 8798 INFO rally.task.runner [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | ITER: 4 END: OK
+2018-06-28 20:07:22.910 8799 INFO rally.task.runner [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | ITER: 3 END: OK
+2018-06-28 20:07:22.932 8670 INFO rally.task.context [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Context cleanup@openstack cleanup() started
+2018-06-28 20:07:35.608 8670 INFO rally.task.context [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Context cleanup@openstack cleanup() finished in 12.68 sec
+2018-06-28 20:07:35.608 8670 INFO rally.task.context [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Context users@openstack cleanup() started
+2018-06-28 20:07:40.721 8670 INFO rally.task.context [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Context users@openstack cleanup() finished in 5.11 sec
+2018-06-28 20:07:41.352 8670 INFO rally.task.engine [-] Load duration is: 145.907436
+2018-06-28 20:07:41.353 8670 INFO rally.task.engine [-] Full runner duration is: 146.952434
+2018-06-28 20:07:41.354 8670 INFO rally.task.engine [-] Full duration is: 168.286262
+2018-06-28 20:07:41.421 8670 INFO rally.task.engine [-] Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_server_attach_created_volume_and_resize
+args position 0
+args values:
+{
+  "runner": {
+    "times": 4, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "image": {
+      "name": "Ubuntu 14.04 LTS"
+    }, 
+    "to_flavor": {
+      "name": "m1.large"
+    }, 
+    "confirm": true, 
+    "volume_size": 1, 
+    "force_delete": false, 
+    "do_delete": true, 
+    "boot_server_kwargs": {}, 
+    "create_volume_kwargs": {}
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task b786732f-471e-4aa6-91f7-9bcbbb40d3c0 has 0 error(s)
+--------------------------------------------------------------------------------
+
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server        | 25.522    | 33.356       | 34.868       | 34.902       | 34.936    | 31.793    | 100.0%  | 4     |
+| cinder_v2.create_volume | 2.402     | 2.413        | 2.436        | 2.44         | 2.444     | 2.418     | 100.0%  | 4     |
+| nova.attach_volume      | 3.464     | 3.694        | 3.884        | 3.917        | 3.951     | 3.701     | 100.0%  | 4     |
+| nova.resize             | 22.662    | 25.404       | 28.057       | 28.08        | 28.103    | 25.393    | 100.0%  | 4     |
+| nova.resize_confirm     | 2.597     | 2.672        | 2.719        | 2.724        | 2.729     | 2.667     | 100.0%  | 4     |
+| nova.detach_volume      | 0.785     | 0.812        | 1.023        | 1.064        | 1.105     | 0.878     | 100.0%  | 4     |
+| cinder_v2.delete_volume | 2.203     | 2.28         | 2.36         | 2.373        | 2.386     | 2.288     | 100.0%  | 4     |
+| nova.delete_server      | 2.465     | 2.524        | 2.624        | 2.642        | 2.659     | 2.543     | 100.0%  | 4     |
+| total                   | 62.495    | 73.449       | 76.375       | 76.853       | 77.331    | 71.681    | 100.0%  | 4     |
+|  -> duration            | 61.495    | 72.449       | 75.375       | 75.853       | 76.331    | 70.681    | 100.0%  | 4     |
+|  -> idle_duration       | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 4     |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 145.907436
+Full duration: 168.286262
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report b786732f-471e-4aa6-91f7-9bcbbb40d3c0 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export b786732f-471e-4aa6-91f7-9bcbbb40d3c0 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report b786732f-471e-4aa6-91f7-9bcbbb40d3c0 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NeutronNetworks.create_and_delete_networks": [
+        {
+            "args": {
+                "network_create_args": {}
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 10
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1
+                    }
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  509b39f7-8246-4c87-adcb-69263975e6a4: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 509b39f7-8246-4c87-adcb-69263975e6a4
+2018-06-28 20:07:43.209 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Starting:  Task validation.
+2018-06-28 20:07:43.215 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Starting:  Task validation of syntax.
+2018-06-28 20:07:43.228 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Completed: Task validation of syntax.
+2018-06-28 20:07:43.228 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Starting:  Task validation of required platforms.
+2018-06-28 20:07:43.232 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Completed: Task validation of required platforms.
+2018-06-28 20:07:43.233 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Starting:  Task validation of semantic.
+2018-06-28 20:07:46.098 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context users@openstack setup()  finished in 2.26 sec
+2018-06-28 20:07:46.603 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context users@openstack cleanup() started
+2018-06-28 20:07:50.047 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context users@openstack cleanup() finished in 3.44 sec
+2018-06-28 20:07:50.048 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Completed: Task validation of semantic.
+2018-06-28 20:07:50.048 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Completed: Task validation.
+2018-06-28 20:07:50.048 8989 INFO rally.api [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 input file is valid.
+2018-06-28 20:07:50.049 8989 INFO rally.api [-] Run Task 509b39f7-8246-4c87-adcb-69263975e6a4 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 20:07:50.049 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Starting:  Running task.
+2018-06-28 20:07:50.119 8989 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=c9515d6c-e86c-48a5-9c83-d4ada2729f62)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_delete_networks", 
+         "description": "Create and delete a network.", 
+         "scenario": {
+            "NeutronNetworks.create_and_delete_networks": {
+               "network_create_args": {}
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1
+               }
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 20:07:52.943 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context users@openstack setup()  finished in 2.78 sec
+2018-06-28 20:07:53.557 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context quotas@openstack setup()  finished in 0.61 sec
+2018-06-28 20:07:53.557 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context cleanup@openstack setup()  finished in 0.06 msec
+2018-06-28 20:07:53.593 9118 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 1 START
+2018-06-28 20:07:53.605 9120 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 3 START
+2018-06-28 20:07:53.609 9123 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 4 START
+2018-06-28 20:07:53.611 9125 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 5 START
+2018-06-28 20:07:53.612 9119 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 2 START
+2018-06-28 20:07:53.613 9126 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 6 START
+2018-06-28 20:07:53.616 9129 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 7 START
+2018-06-28 20:07:53.619 9130 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 8 START
+2018-06-28 20:07:53.626 9136 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 9 START
+2018-06-28 20:07:53.629 9139 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 10 START
+2018-06-28 20:07:55.286 9118 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 1 END: OK
+2018-06-28 20:07:55.296 9136 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 9 END: OK
+2018-06-28 20:07:55.362 9120 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 3 END: OK
+2018-06-28 20:07:55.381 9130 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 8 END: OK
+2018-06-28 20:07:55.409 9125 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 5 END: OK
+2018-06-28 20:07:55.448 9123 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 4 END: OK
+2018-06-28 20:07:55.481 9126 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 6 END: OK
+2018-06-28 20:07:55.610 9119 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 2 END: OK
+2018-06-28 20:07:55.670 9139 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 10 END: OK
+2018-06-28 20:07:55.677 9129 INFO rally.task.runner [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | ITER: 7 END: OK
+2018-06-28 20:07:55.701 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context cleanup@openstack cleanup() started
+2018-06-28 20:08:11.633 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context cleanup@openstack cleanup() finished in 15.93 sec
+2018-06-28 20:08:11.633 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context quotas@openstack cleanup() started
+2018-06-28 20:08:11.725 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context quotas@openstack cleanup() finished in 91.42 msec
+2018-06-28 20:08:11.725 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context users@openstack cleanup() started
+2018-06-28 20:08:16.785 8989 INFO rally.task.context [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Context users@openstack cleanup() finished in 5.06 sec
+2018-06-28 20:08:18.423 8989 INFO rally.task.engine [-] Load duration is: 2.076814
+2018-06-28 20:08:18.423 8989 INFO rally.task.engine [-] Full runner duration is: 2.135684
+2018-06-28 20:08:18.423 8989 INFO rally.task.engine [-] Full duration is: 26.651806
+2018-06-28 20:08:18.501 8989 INFO rally.task.engine [-] Task 509b39f7-8246-4c87-adcb-69263975e6a4 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 509b39f7-8246-4c87-adcb-69263975e6a4: finished
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_delete_networks
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1
+      }
+    }
+  }, 
+  "args": {
+    "network_create_args": {}
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 509b39f7-8246-4c87-adcb-69263975e6a4 has 0 error(s)
+--------------------------------------------------------------------------------
+
++---------------------------------------------------------------------------------------------------------------------------+
+|                                                   Response Times (sec)                                                    |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                 | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_network | 0.859     | 1.027        | 1.156        | 1.167        | 1.178     | 1.015     | 100.0%  | 10    |
+| neutron.delete_network | 0.663     | 0.844        | 0.893        | 0.926        | 0.958     | 0.832     | 100.0%  | 10    |
+| total                  | 1.669     | 1.816        | 2.042        | 2.05         | 2.059     | 1.846     | 100.0%  | 10    |
+|  -> duration           | 1.669     | 1.816        | 2.042        | 2.05         | 2.059     | 1.846     | 100.0%  | 10    |
+|  -> idle_duration      | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 10    |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 2.076814
+Full duration: 26.651806
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 509b39f7-8246-4c87-adcb-69263975e6a4 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 509b39f7-8246-4c87-adcb-69263975e6a4 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 509b39f7-8246-4c87-adcb-69263975e6a4 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+  "NovaServers.boot_and_delete_multiple_servers": [
+    {
+      "runner": {
+        "type": "constant",
+        "concurrency": 2,
+        "times": 3
+      },
+      "args": {
+        "count": 5,
+        "image": {
+          "name": "Ubuntu 16.04"
+        },
+        "flavor": {
+          "name": "m1.small"
+        }
+      },
+      "context": {
+        "users": {
+          "users_per_tenant": 1,
+          "tenants": 1
+        }
+      },
+      "sla": {
+         "failure_rate": {
+           "max": 0
+         }
+      }
+    }
+  ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  1d723d50-2d4d-491b-a461-5f68f18714a2: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 1d723d50-2d4d-491b-a461-5f68f18714a2
+2018-06-28 20:08:20.372 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Starting:  Task validation.
+2018-06-28 20:08:20.383 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Starting:  Task validation of syntax.
+2018-06-28 20:08:20.399 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Completed: Task validation of syntax.
+2018-06-28 20:08:20.399 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Starting:  Task validation of required platforms.
+2018-06-28 20:08:20.407 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Completed: Task validation of required platforms.
+2018-06-28 20:08:20.407 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Starting:  Task validation of semantic.
+2018-06-28 20:08:23.398 9401 INFO rally.task.context [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Context users@openstack setup()  finished in 2.36 sec
+2018-06-28 20:08:24.811 9401 INFO rally.task.context [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Context users@openstack cleanup() started
+2018-06-28 20:08:28.184 9401 INFO rally.task.context [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Context users@openstack cleanup() finished in 3.37 sec
+2018-06-28 20:08:28.185 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Completed: Task validation of semantic.
+2018-06-28 20:08:28.185 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Completed: Task validation.
+2018-06-28 20:08:28.185 9401 INFO rally.api [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 input file is valid.
+2018-06-28 20:08:28.186 9401 INFO rally.api [-] Run Task 1d723d50-2d4d-491b-a461-5f68f18714a2 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 20:08:28.186 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Starting:  Running task.
+2018-06-28 20:08:28.232 9401 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=28f6e63e-5cef-4ead-867d-7af410134b55)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_and_delete_multiple_servers", 
+         "description": "Boot multiple servers in a single request and delete them.", 
+         "scenario": {
+            "NovaServers.boot_and_delete_multiple_servers": {
+               "count": 5, 
+               "image": {
+                  "name": "Ubuntu 16.04"
+               }, 
+               "flavor": {
+                  "name": "m1.small"
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "users_per_tenant": 1, 
+               "tenants": 1
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "concurrency": 2, 
+               "times": 3
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 20:08:30.994 9401 INFO rally.task.context [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Context users@openstack setup()  finished in 2.73 sec
+2018-06-28 20:08:30.995 9401 INFO rally.task.context [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Context cleanup@openstack setup()  finished in 0.04 msec
+2018-06-28 20:08:31.877 9529 INFO rally.task.runner [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | ITER: 1 START
+2018-06-28 20:08:31.880 9530 INFO rally.task.runner [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | ITER: 2 START
+2018-06-28 20:09:50.768 9529 INFO rally.task.runner [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | ITER: 1 END: OK
+2018-06-28 20:09:50.774 9529 INFO rally.task.runner [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | ITER: 3 START
+2018-06-28 20:09:52.438 9530 INFO rally.task.runner [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | ITER: 2 END: OK
+2018-06-28 20:10:39.182 9529 INFO rally.task.runner [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | ITER: 3 END: OK
+2018-06-28 20:10:39.207 9401 INFO rally.task.context [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Context cleanup@openstack cleanup() started
+2018-06-28 20:10:40.624 9401 INFO rally.task.context [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Context cleanup@openstack cleanup() finished in 1.42 sec
+2018-06-28 20:10:40.625 9401 INFO rally.task.context [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Context users@openstack cleanup() started
+2018-06-28 20:10:43.666 9401 INFO rally.task.context [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Context users@openstack cleanup() finished in 3.04 sec
+2018-06-28 20:10:44.980 9401 INFO rally.task.engine [-] Load duration is: 126.302461
+2018-06-28 20:10:44.980 9401 INFO rally.task.engine [-] Full runner duration is: 127.347187
+2018-06-28 20:10:44.980 9401 INFO rally.task.engine [-] Full duration is: 135.428404
+2018-06-28 20:10:45.044 9401 INFO rally.task.engine [-] Task 1d723d50-2d4d-491b-a461-5f68f18714a2 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 1d723d50-2d4d-491b-a461-5f68f18714a2: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_and_delete_multiple_servers
+args position 0
+args values:
+{
+  "runner": {
+    "concurrency": 2, 
+    "times": 3
+  }, 
+  "contexts": {
+    "users": {
+      "users_per_tenant": 1, 
+      "tenants": 1
+    }
+  }, 
+  "args": {
+    "count": 5, 
+    "image": {
+      "name": "Ubuntu 16.04"
+    }, 
+    "flavor": {
+      "name": "m1.small"
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 1d723d50-2d4d-491b-a461-5f68f18714a2 has 0 error(s)
+--------------------------------------------------------------------------------
+
++------------------------------------------------------------------------------------------------------------------------+
+|                                                  Response Times (sec)                                                  |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action              | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_servers   | 44.864    | 74.949       | 75.195       | 75.226       | 75.257    | 65.023    | 100.0%  | 3     |
+| nova.delete_servers | 3.544     | 3.63         | 5.212        | 5.409        | 5.607     | 4.26      | 100.0%  | 3     |
+| total               | 48.408    | 78.888       | 80.223       | 80.389       | 80.556    | 69.284    | 100.0%  | 3     |
+|  -> duration        | 47.408    | 77.888       | 79.223       | 79.389       | 79.556    | 68.284    | 100.0%  | 3     |
+|  -> idle_duration   | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 3     |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 126.302461
+Full duration: 135.428404
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 1d723d50-2d4d-491b-a461-5f68f18714a2 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 1d723d50-2d4d-491b-a461-5f68f18714a2 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 1d723d50-2d4d-491b-a461-5f68f18714a2 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "CinderVolumes.create_and_attach_volume": [
+        {
+            "args": {
+                "size": 50,
+                "image": {
+                    "name": "Ubuntu 16.04"
+                },
+                "flavor": {
+                    "name": "m1.xlarge"
+                },
+                "create_volume_params": {
+                    "availability_zone": "nova"
+                }
+            },
+            "runner": {
+                "type": "constant",
+                "times": 20,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 2,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        },
+        {
+            "args": {
+                "size": {
+                    "min": 20,
+                    "max": 50
+                },
+                "flavor": {
+                    "name": "m1.large"
+                },
+                "image": {
+                    "name": "Ubuntu 16.04"
+                },
+                "create_volume_params": {
+                    "availability_zone": "nova"
+                }
+            },
+            "runner": {
+                "type": "constant",
+                "times": 20,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 2,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  7cc61200-7723-4b22-921d-4d4690647db6: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 7cc61200-7723-4b22-921d-4d4690647db6
+2018-06-28 20:10:46.801 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Starting:  Task validation.
+2018-06-28 20:10:46.808 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Starting:  Task validation of syntax.
+2018-06-28 20:10:46.826 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Completed: Task validation of syntax.
+2018-06-28 20:10:46.826 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Starting:  Task validation of required platforms.
+2018-06-28 20:10:46.835 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Completed: Task validation of required platforms.
+2018-06-28 20:10:46.836 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Starting:  Task validation of semantic.
+2018-06-28 20:10:49.925 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context users@openstack setup()  finished in 2.38 sec
+2018-06-28 20:10:52.533 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context users@openstack cleanup() started
+2018-06-28 20:10:56.060 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context users@openstack cleanup() finished in 3.53 sec
+2018-06-28 20:10:56.060 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Completed: Task validation of semantic.
+2018-06-28 20:10:56.061 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Completed: Task validation.
+2018-06-28 20:10:56.061 9666 INFO rally.api [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 input file is valid.
+2018-06-28 20:10:56.061 9666 INFO rally.api [-] Run Task 7cc61200-7723-4b22-921d-4d4690647db6 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 20:10:56.062 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Starting:  Running task.
+2018-06-28 20:10:56.121 9666 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=36cfd4be-dfda-4a5e-af52-19948c49d007)", 
+   "subtasks": [
+      {
+         "title": "CinderVolumes.create_and_attach_volume", 
+         "description": "Create a VM and attach a volume to it.", 
+         "scenario": {
+            "CinderVolumes.create_and_attach_volume": {
+               "size": 50, 
+               "image": {
+                  "name": "Ubuntu 16.04"
+               }, 
+               "flavor": {
+                  "name": "m1.xlarge"
+               }, 
+               "create_volume_params": {
+                  "availability_zone": "nova"
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 2, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 20, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 20:10:58.865 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context users@openstack setup()  finished in 2.71 sec
+2018-06-28 20:10:58.866 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context cleanup@openstack setup()  finished in 0.14 msec
+2018-06-28 20:10:59.717 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 1 START
+2018-06-28 20:10:59.719 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 2 START
+2018-06-28 20:14:16.097 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 2 END: OK
+2018-06-28 20:14:16.103 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 3 START
+2018-06-28 20:14:20.617 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 1 END: OK
+2018-06-28 20:14:20.622 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 4 START
+2018-06-28 20:17:18.303 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 3 END: OK
+2018-06-28 20:17:18.309 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 5 START
+2018-06-28 20:17:43.308 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 4 END: OK
+2018-06-28 20:17:43.312 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 6 START
+2018-06-28 20:20:21.642 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 6 END: OK
+2018-06-28 20:20:21.646 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 7 START
+2018-06-28 20:20:37.699 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 5 END: OK
+2018-06-28 20:20:37.702 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 8 START
+2018-06-28 20:22:32.768 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 7 END: OK
+2018-06-28 20:22:32.771 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 9 START
+2018-06-28 20:22:35.205 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 8 END: OK
+2018-06-28 20:22:35.208 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 10 START
+2018-06-28 20:25:25.632 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 10 END: OK
+2018-06-28 20:25:25.636 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 11 START
+2018-06-28 20:25:54.603 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 9 END: OK
+2018-06-28 20:25:54.608 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 12 START
+2018-06-28 20:28:34.028 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 11 END: OK
+2018-06-28 20:28:34.032 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 13 START
+2018-06-28 20:29:15.164 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 12 END: OK
+2018-06-28 20:29:15.168 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 14 START
+2018-06-28 20:30:58.941 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 13 END: OK
+2018-06-28 20:30:58.946 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 15 START
+2018-06-28 20:32:37.775 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 14 END: OK
+2018-06-28 20:32:37.779 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 16 START
+2018-06-28 20:33:06.006 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 15 END: OK
+2018-06-28 20:33:06.010 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 17 START
+2018-06-28 20:35:46.023 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 16 END: OK
+2018-06-28 20:35:46.027 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 18 START
+2018-06-28 20:35:46.097 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 17 END: OK
+2018-06-28 20:35:46.101 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 19 START
+2018-06-28 20:38:10.779 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 19 END: OK
+2018-06-28 20:38:10.784 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 20 START
+2018-06-28 20:38:52.118 9795 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 18 END: OK
+2018-06-28 20:41:57.644 9796 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 20 END: OK
+2018-06-28 20:41:57.668 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context cleanup@openstack cleanup() started
+2018-06-28 20:42:06.058 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context cleanup@openstack cleanup() finished in 8.39 sec
+2018-06-28 20:42:06.058 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context users@openstack cleanup() started
+2018-06-28 20:42:10.310 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context users@openstack cleanup() finished in 4.25 sec
+2018-06-28 20:42:11.645 9666 INFO rally.task.engine [-] Load duration is: 1856.922641
+2018-06-28 20:42:11.645 9666 INFO rally.task.engine [-] Full runner duration is: 1857.968779
+2018-06-28 20:42:11.646 9666 INFO rally.task.engine [-] Full duration is: 1874.177553
+2018-06-28 20:42:11.731 9666 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=61513ee3-ac3c-4271-b261-3de3ed62d8bd)", 
+   "subtasks": [
+      {
+         "title": "CinderVolumes.create_and_attach_volume", 
+         "description": "Create a VM and attach a volume to it.", 
+         "scenario": {
+            "CinderVolumes.create_and_attach_volume": {
+               "size": {
+                  "min": 20, 
+                  "max": 50
+               }, 
+               "flavor": {
+                  "name": "m1.large"
+               }, 
+               "image": {
+                  "name": "Ubuntu 16.04"
+               }, 
+               "create_volume_params": {
+                  "availability_zone": "nova"
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 2, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 20, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 20:42:14.310 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context users@openstack setup()  finished in 2.55 sec
+2018-06-28 20:42:14.311 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context cleanup@openstack setup()  finished in 0.02 msec
+2018-06-28 20:42:15.085 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 1 START
+2018-06-28 20:42:15.088 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 2 START
+2018-06-28 20:44:14.484 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 2 END: OK
+2018-06-28 20:44:14.491 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 3 START
+2018-06-28 20:44:15.748 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 1 END: OK
+2018-06-28 20:44:15.755 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 4 START
+2018-06-28 20:45:35.049 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 3 END: OK
+2018-06-28 20:45:35.053 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 5 START
+2018-06-28 20:46:38.135 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 4 END: OK
+2018-06-28 20:46:38.140 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 6 START
+2018-06-28 20:47:15.233 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 5 END: OK
+2018-06-28 20:47:15.238 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 7 START
+2018-06-28 20:49:00.740 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 7 END: OK
+2018-06-28 20:49:00.746 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 8 START
+2018-06-28 20:49:03.420 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 6 END: OK
+2018-06-28 20:49:03.425 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 9 START
+2018-06-28 20:50:28.665 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 9 END: OK
+2018-06-28 20:50:28.670 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 10 START
+2018-06-28 20:50:29.132 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 8 END: OK
+2018-06-28 20:50:29.136 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 11 START
+2018-06-28 20:52:23.641 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 11 END: OK
+2018-06-28 20:52:23.645 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 12 START
+2018-06-28 20:53:02.536 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 10 END: OK
+2018-06-28 20:53:02.541 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 13 START
+2018-06-28 20:53:42.402 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 12 END: OK
+2018-06-28 20:53:42.406 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 14 START
+2018-06-28 20:54:16.634 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 13 END: OK
+2018-06-28 20:54:16.639 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 15 START
+2018-06-28 20:54:58.802 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 14 END: OK
+2018-06-28 20:54:58.806 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 16 START
+2018-06-28 20:55:32.433 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 15 END: OK
+2018-06-28 20:55:32.438 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 17 START
+2018-06-28 20:56:14.449 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 16 END: OK
+2018-06-28 20:56:14.455 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 18 START
+2018-06-28 20:56:51.185 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 17 END: OK
+2018-06-28 20:56:51.190 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 19 START
+2018-06-28 20:57:30.526 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 18 END: OK
+2018-06-28 20:57:30.531 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 20 START
+2018-06-28 20:58:09.158 10162 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 19 END: OK
+2018-06-28 20:58:48.814 10163 INFO rally.task.runner [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | ITER: 20 END: OK
+2018-06-28 20:58:48.842 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context cleanup@openstack cleanup() started
+2018-06-28 20:58:57.269 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context cleanup@openstack cleanup() finished in 8.43 sec
+2018-06-28 20:58:57.270 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context users@openstack cleanup() started
+2018-06-28 20:59:01.648 9666 INFO rally.task.context [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Context users@openstack cleanup() finished in 4.38 sec
+2018-06-28 20:59:02.913 9666 INFO rally.task.engine [-] Load duration is: 992.724569
+2018-06-28 20:59:02.913 9666 INFO rally.task.engine [-] Full runner duration is: 993.775283
+2018-06-28 20:59:02.913 9666 INFO rally.task.engine [-] Full duration is: 1009.910084
+2018-06-28 20:59:02.999 9666 INFO rally.task.engine [-] Task 7cc61200-7723-4b22-921d-4d4690647db6 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 7cc61200-7723-4b22-921d-4d4690647db6: finished
+--------------------------------------------------------------------------------
+
+test scenario CinderVolumes.create_and_attach_volume
+args position 0
+args values:
+{
+  "runner": {
+    "times": 20, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 2, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "size": 50, 
+    "image": {
+      "name": "Ubuntu 16.04"
+    }, 
+    "flavor": {
+      "name": "m1.xlarge"
+    }, 
+    "create_volume_params": {
+      "availability_zone": "nova"
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 7cc61200-7723-4b22-921d-4d4690647db6 has 0 error(s)
+--------------------------------------------------------------------------------
+
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server        | 105.683   | 170.836      | 188.225      | 188.47       | 188.872   | 161.172   | 100.0%  | 20    |
+| cinder_v2.create_volume | 2.386     | 2.441        | 2.502        | 2.516        | 2.621     | 2.445     | 100.0%  | 20    |
+| nova.attach_volume      | 3.408     | 3.548        | 3.716        | 3.744        | 3.76      | 3.575     | 100.0%  | 20    |
+| nova.detach_volume      | 0.75      | 0.857        | 3.362        | 3.432        | 3.473     | 1.232     | 100.0%  | 20    |
+| cinder_v2.delete_volume | 2.201     | 2.25         | 2.288        | 2.296        | 2.391     | 2.256     | 100.0%  | 20    |
+| nova.delete_server      | 2.613     | 4.732        | 4.861        | 6.299        | 32.645    | 5.83      | 100.0%  | 20    |
+| total                   | 117.502   | 187.165      | 202.613      | 203.892      | 226.858   | 176.51    | 100.0%  | 20    |
+|  -> duration            | 116.502   | 186.165      | 201.613      | 202.892      | 225.858   | 175.51    | 100.0%  | 20    |
+|  -> idle_duration       | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 20    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 1856.922641
+Full duration: 1874.177553
+--------------------------------------------------------------------------------
+
+test scenario CinderVolumes.create_and_attach_volume
+args position 0
+args values:
+{
+  "runner": {
+    "times": 20, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 2, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "size": {
+      "min": 20, 
+      "max": 50
+    }, 
+    "flavor": {
+      "name": "m1.large"
+    }, 
+    "image": {
+      "name": "Ubuntu 16.04"
+    }, 
+    "create_volume_params": {
+      "availability_zone": "nova"
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 7cc61200-7723-4b22-921d-4d4690647db6 has 0 error(s)
+--------------------------------------------------------------------------------
+
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server        | 62.389    | 68.705       | 113.251      | 121.426      | 142.32    | 81.357    | 100.0%  | 20    |
+| cinder_v2.create_volume | 2.392     | 2.441        | 2.539        | 2.544        | 2.566     | 2.458     | 100.0%  | 20    |
+| nova.attach_volume      | 3.401     | 3.513        | 3.741        | 3.786        | 3.815     | 3.563     | 100.0%  | 20    |
+| nova.detach_volume      | 0.73      | 0.903        | 3.396        | 3.442        | 3.483     | 1.74      | 100.0%  | 20    |
+| cinder_v2.delete_volume | 2.201     | 2.257        | 4.297        | 4.301        | 4.312     | 2.658     | 100.0%  | 20    |
+| nova.delete_server      | 2.457     | 2.666        | 16.154       | 16.772       | 18.307    | 5.607     | 100.0%  | 20    |
+| total                   | 74.092    | 82.897       | 142.668      | 145.707      | 153.864   | 97.383    | 100.0%  | 20    |
+|  -> duration            | 73.092    | 81.897       | 141.668      | 144.707      | 152.864   | 96.383    | 100.0%  | 20    |
+|  -> idle_duration       | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 20    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 992.724569
+Full duration: 1009.910084
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 7cc61200-7723-4b22-921d-4d4690647db6 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 7cc61200-7723-4b22-921d-4d4690647db6 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 7cc61200-7723-4b22-921d-4d4690647db6 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "CinderVolumes.create_and_accept_transfer": [
+        {
+            "args": {
+                "size": 20
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 2,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  66c839b8-a601-475a-ae12-94de4ee7a050: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 66c839b8-a601-475a-ae12-94de4ee7a050
+2018-06-28 20:59:04.988 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Starting:  Task validation.
+2018-06-28 20:59:04.998 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Starting:  Task validation of syntax.
+2018-06-28 20:59:05.015 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Completed: Task validation of syntax.
+2018-06-28 20:59:05.015 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Starting:  Task validation of required platforms.
+2018-06-28 20:59:05.022 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Completed: Task validation of required platforms.
+2018-06-28 20:59:05.023 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Starting:  Task validation of semantic.
+2018-06-28 20:59:08.062 11313 INFO rally.task.context [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Context users@openstack setup()  finished in 2.33 sec
+2018-06-28 20:59:08.443 11313 INFO rally.task.context [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Context users@openstack cleanup() started
+2018-06-28 20:59:11.964 11313 INFO rally.task.context [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Context users@openstack cleanup() finished in 3.52 sec
+2018-06-28 20:59:11.965 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Completed: Task validation of semantic.
+2018-06-28 20:59:11.966 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Completed: Task validation.
+2018-06-28 20:59:11.966 11313 INFO rally.api [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 input file is valid.
+2018-06-28 20:59:11.966 11313 INFO rally.api [-] Run Task 66c839b8-a601-475a-ae12-94de4ee7a050 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 20:59:11.967 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Starting:  Running task.
+2018-06-28 20:59:12.013 11313 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=bb08cc80-e553-4f80-921b-c93a311d7bc5)", 
+   "subtasks": [
+      {
+         "title": "CinderVolumes.create_and_accept_transfer", 
+         "description": "Create a volume transfer, then accept it", 
+         "scenario": {
+            "CinderVolumes.create_and_accept_transfer": {
+               "size": 20
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 2, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 20:59:14.616 11313 INFO rally.task.context [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Context users@openstack setup()  finished in 2.57 sec
+2018-06-28 20:59:14.617 11313 INFO rally.task.context [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Context cleanup@openstack setup()  finished in 0.02 msec
+2018-06-28 20:59:14.642 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 1 START
+2018-06-28 20:59:14.644 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 2 START
+2018-06-28 20:59:18.134 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 2 END: OK
+2018-06-28 20:59:18.139 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 3 START
+2018-06-28 20:59:18.235 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 1 END: OK
+2018-06-28 20:59:18.238 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 4 START
+2018-06-28 20:59:21.404 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 3 END: OK
+2018-06-28 20:59:21.408 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 5 START
+2018-06-28 20:59:21.589 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 4 END: OK
+2018-06-28 20:59:21.592 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 6 START
+2018-06-28 20:59:24.842 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 6 END: OK
+2018-06-28 20:59:24.845 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 7 START
+2018-06-28 20:59:24.854 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 5 END: OK
+2018-06-28 20:59:24.857 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 8 START
+2018-06-28 20:59:28.042 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 7 END: OK
+2018-06-28 20:59:28.045 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 9 START
+2018-06-28 20:59:28.085 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 8 END: OK
+2018-06-28 20:59:28.088 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 10 START
+2018-06-28 20:59:31.294 11446 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 9 END: OK
+2018-06-28 20:59:31.389 11447 INFO rally.task.runner [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | ITER: 10 END: OK
+2018-06-28 20:59:31.409 11313 INFO rally.task.context [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Context cleanup@openstack cleanup() started
+2018-06-28 20:59:38.531 11313 INFO rally.task.context [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Context cleanup@openstack cleanup() finished in 7.12 sec
+2018-06-28 20:59:38.531 11313 INFO rally.task.context [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Context users@openstack cleanup() started
+2018-06-28 20:59:42.739 11313 INFO rally.task.context [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Context users@openstack cleanup() finished in 4.21 sec
+2018-06-28 20:59:44.221 11313 INFO rally.task.engine [-] Load duration is: 16.742054
+2018-06-28 20:59:44.222 11313 INFO rally.task.engine [-] Full runner duration is: 16.784917
+2018-06-28 20:59:44.222 11313 INFO rally.task.engine [-] Full duration is: 30.717417
+2018-06-28 20:59:44.291 11313 INFO rally.task.engine [-] Task 66c839b8-a601-475a-ae12-94de4ee7a050 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 66c839b8-a601-475a-ae12-94de4ee7a050: finished
+--------------------------------------------------------------------------------
+
+test scenario CinderVolumes.create_and_accept_transfer
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 2, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "size": 20
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 66c839b8-a601-475a-ae12-94de4ee7a050 has 0 error(s)
+--------------------------------------------------------------------------------
+
++------------------------------------------------------------------------------------------------------------------------------+
+|                                                     Response Times (sec)                                                     |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                    | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume   | 2.805     | 2.865        | 3.107        | 3.144        | 3.182     | 2.929     | 100.0%  | 10    |
+| cinder_v2.transfer_create | 0.057     | 0.067        | 0.081        | 0.085        | 0.089     | 0.07      | 100.0%  | 10    |
+| cinder_v2.transfer_accept | 0.257     | 0.299        | 0.343        | 0.368        | 0.393     | 0.309     | 100.0%  | 10    |
+| total                     | 3.195     | 3.281        | 3.497        | 3.542        | 3.588     | 3.335     | 100.0%  | 10    |
+|  -> duration              | 3.195     | 3.281        | 3.497        | 3.542        | 3.588     | 3.335     | 100.0%  | 10    |
+|  -> idle_duration         | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 10    |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 16.742054
+Full duration: 30.717417
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 66c839b8-a601-475a-ae12-94de4ee7a050 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 66c839b8-a601-475a-ae12-94de4ee7a050 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 66c839b8-a601-475a-ae12-94de4ee7a050 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NovaServers.boot_server_from_volume_and_delete": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "image": {
+                    "name": "Ubuntu 16.04"
+                },
+                "volume_size": 50,
+                "volume_type": "",
+                "force_delete": false
+            },
+            "runner": {
+                "type": "constant",
+                "times": 50,
+                "concurrency": 5
+            },
+            "context": {
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  bfa87348-5ee6-42af-a1d9-2e85e7ae0dca: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: bfa87348-5ee6-42af-a1d9-2e85e7ae0dca
+2018-06-28 20:59:46.178 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Starting:  Task validation.
+2018-06-28 20:59:46.189 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Starting:  Task validation of syntax.
+2018-06-28 20:59:46.202 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Completed: Task validation of syntax.
+2018-06-28 20:59:46.202 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Starting:  Task validation of required platforms.
+2018-06-28 20:59:46.209 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Completed: Task validation of required platforms.
+2018-06-28 20:59:46.209 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Starting:  Task validation of semantic.
+2018-06-28 20:59:49.264 11589 INFO rally.task.context [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Context users@openstack setup()  finished in 2.44 sec
+2018-06-28 20:59:50.901 11589 INFO rally.task.context [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Context users@openstack cleanup() started
+2018-06-28 20:59:54.431 11589 INFO rally.task.context [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Context users@openstack cleanup() finished in 3.53 sec
+2018-06-28 20:59:54.431 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Completed: Task validation of semantic.
+2018-06-28 20:59:54.432 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Completed: Task validation.
+2018-06-28 20:59:54.432 11589 INFO rally.api [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca input file is valid.
+2018-06-28 20:59:54.432 11589 INFO rally.api [-] Run Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 20:59:54.433 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Starting:  Running task.
+2018-06-28 20:59:54.478 11589 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=b1500bb9-ff69-4545-b58a-6b0c7a21fd34)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_server_from_volume_and_delete", 
+         "description": "Boot a server from volume and then delete it.", 
+         "scenario": {
+            "NovaServers.boot_server_from_volume_and_delete": {
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "image": {
+                  "name": "Ubuntu 16.04"
+               }, 
+               "volume_size": 50, 
+               "volume_type": "", 
+               "force_delete": false
+            }
+         }, 
+         "contexts": {}, 
+         "runner": {
+            "constant": {
+               "times": 50, 
+               "concurrency": 5
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 20:59:57.187 11589 INFO rally.task.context [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Context users@openstack setup()  finished in 2.68 sec
+2018-06-28 20:59:57.187 11589 INFO rally.task.context [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-28 20:59:57.877 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 1 START
+2018-06-28 20:59:57.879 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 2 START
+2018-06-28 20:59:57.884 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 3 START
+2018-06-28 20:59:57.888 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 4 START
+2018-06-28 20:59:57.893 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 5 START
+2018-06-28 21:01:10.563 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 5 END: OK
+2018-06-28 21:01:10.569 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 6 START
+2018-06-28 21:01:11.485 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 3 END: OK
+2018-06-28 21:01:11.490 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 7 START
+2018-06-28 21:01:17.240 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 2 END: OK
+2018-06-28 21:01:17.247 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 8 START
+2018-06-28 21:01:17.255 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 4 END: OK
+2018-06-28 21:01:17.260 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 9 START
+2018-06-28 21:01:19.408 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 1 END: OK
+2018-06-28 21:01:19.414 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 10 START
+2018-06-28 21:01:55.531 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 6 END: OK
+2018-06-28 21:01:55.536 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 11 START
+2018-06-28 21:02:04.278 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 7 END: OK
+2018-06-28 21:02:04.281 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 12 START
+2018-06-28 21:02:14.444 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 8 END: OK
+2018-06-28 21:02:14.449 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 13 START
+2018-06-28 21:02:21.106 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 10 END: OK
+2018-06-28 21:02:21.110 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 14 START
+2018-06-28 21:02:21.469 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 9 END: OK
+2018-06-28 21:02:21.473 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 15 START
+2018-06-28 21:02:34.181 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 11 END: OK
+2018-06-28 21:02:34.186 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 16 START
+2018-06-28 21:02:47.360 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 12 END: OK
+2018-06-28 21:02:47.364 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 17 START
+2018-06-28 21:02:54.959 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 13 END: OK
+2018-06-28 21:02:54.964 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 18 START
+2018-06-28 21:03:12.425 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 14 END: OK
+2018-06-28 21:03:12.429 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 19 START
+2018-06-28 21:03:12.600 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 15 END: OK
+2018-06-28 21:03:12.603 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 20 START
+2018-06-28 21:03:14.440 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 16 END: OK
+2018-06-28 21:03:14.443 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 21 START
+2018-06-28 21:03:25.753 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 17 END: OK
+2018-06-28 21:03:25.757 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 22 START
+2018-06-28 21:03:40.378 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 18 END: OK
+2018-06-28 21:03:40.382 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 23 START
+2018-06-28 21:04:01.858 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 20 END: OK
+2018-06-28 21:04:01.863 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 24 START
+2018-06-28 21:04:07.136 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 21 END: OK
+2018-06-28 21:04:07.140 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 25 START
+2018-06-28 21:04:07.487 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 19 END: OK
+2018-06-28 21:04:07.491 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 26 START
+2018-06-28 21:04:07.693 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 22 END: OK
+2018-06-28 21:04:07.697 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 27 START
+2018-06-28 21:04:16.328 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 23 END: Error GetResourceFailure: Failed to get the resource <Server: s_rally_b1500bb9_RRzDOLG6>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-b1e7677c-69e1-45e8-b6d9-1cdc256ba8b5)
+2018-06-28 21:04:16.331 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 28 START
+2018-06-28 21:04:40.473 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 24 END: OK
+2018-06-28 21:04:40.478 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 29 START
+2018-06-28 21:04:51.564 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 25 END: OK
+2018-06-28 21:04:51.569 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 30 START
+2018-06-28 21:05:00.674 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 26 END: OK
+2018-06-28 21:05:00.678 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 31 START
+2018-06-28 21:05:02.869 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 27 END: OK
+2018-06-28 21:05:02.871 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 32 START
+2018-06-28 21:05:09.080 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 28 END: OK
+2018-06-28 21:05:09.084 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 33 START
+2018-06-28 21:05:18.757 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 29 END: OK
+2018-06-28 21:05:18.760 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 34 START
+2018-06-28 21:05:31.997 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 30 END: OK
+2018-06-28 21:05:32.001 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 35 START
+2018-06-28 21:05:45.312 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 31 END: OK
+2018-06-28 21:05:45.316 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 36 START
+2018-06-28 21:05:51.677 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 32 END: OK
+2018-06-28 21:05:51.682 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 37 START
+2018-06-28 21:05:53.165 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 33 END: OK
+2018-06-28 21:05:53.169 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 38 START
+2018-06-28 21:06:01.238 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 34 END: OK
+2018-06-28 21:06:01.242 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 39 START
+2018-06-28 21:06:14.687 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 35 END: OK
+2018-06-28 21:06:14.691 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 40 START
+2018-06-28 21:06:23.717 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 36 END: OK
+2018-06-28 21:06:23.720 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 41 START
+2018-06-28 21:06:41.303 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 37 END: OK
+2018-06-28 21:06:41.307 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 42 START
+2018-06-28 21:06:41.887 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 38 END: OK
+2018-06-28 21:06:41.891 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 43 START
+2018-06-28 21:06:45.948 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 39 END: OK
+2018-06-28 21:06:45.953 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 44 START
+2018-06-28 21:06:53.083 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 40 END: OK
+2018-06-28 21:06:53.087 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 45 START
+2018-06-28 21:07:04.321 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 41 END: OK
+2018-06-28 21:07:04.324 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 46 START
+2018-06-28 21:07:23.779 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 42 END: OK
+2018-06-28 21:07:23.782 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 47 START
+2018-06-28 21:07:34.741 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 43 END: OK
+2018-06-28 21:07:34.745 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 48 START
+2018-06-28 21:07:37.510 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 44 END: OK
+2018-06-28 21:07:37.515 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 49 START
+2018-06-28 21:07:39.692 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 45 END: OK
+2018-06-28 21:07:39.696 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 50 START
+2018-06-28 21:07:42.588 11718 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 46 END: OK
+2018-06-28 21:08:04.564 11720 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 47 END: OK
+2018-06-28 21:08:24.125 11723 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 49 END: OK
+2018-06-28 21:08:25.249 11719 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 48 END: OK
+2018-06-28 21:08:28.383 11726 INFO rally.task.runner [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | ITER: 50 END: OK
+2018-06-28 21:08:28.414 11589 INFO rally.task.context [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Context cleanup@openstack cleanup() started
+2018-06-28 21:08:35.028 11589 INFO rally.task.context [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Context cleanup@openstack cleanup() finished in 6.61 sec
+2018-06-28 21:08:35.029 11589 INFO rally.task.context [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Context users@openstack cleanup() started
+2018-06-28 21:08:38.005 11589 INFO rally.task.context [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Context users@openstack cleanup() finished in 2.98 sec
+2018-06-28 21:08:39.081 11589 INFO rally.task.engine [-] Load duration is: 509.501171
+2018-06-28 21:08:39.082 11589 INFO rally.task.engine [-] Full runner duration is: 510.552644
+2018-06-28 21:08:39.082 11589 INFO rally.task.engine [-] Full duration is: 523.520381
+2018-06-28 21:08:39.186 11589 INFO rally.task.engine [-] Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_server_from_volume_and_delete
+args position 0
+args values:
+{
+  "runner": {
+    "times": 50, 
+    "concurrency": 5
+  }, 
+  "contexts": {}, 
+  "args": {
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "image": {
+      "name": "Ubuntu 16.04"
+    }, 
+    "volume_size": 50, 
+    "volume_type": "", 
+    "force_delete": false
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task bfa87348-5ee6-42af-a1d9-2e85e7ae0dca has 1 error(s)
+--------------------------------------------------------------------------------
+
+GetResourceFailure: Failed to get the resource <Server: s_rally_b1500bb9_RRzDOLG6>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-b1e7677c-69e1-45e8-b6d9-1cdc256ba8b5)
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 195, in run
+    self._delete_server(server, force=force_delete)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 387, in _delete_server
+    check_interval=CONF.openstack.nova_server_delete_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 80, in _get_from_manager
+    raise exceptions.GetResourceFailure(resource=resource, err=e)
+GetResourceFailure: Failed to get the resource <Server: s_rally_b1500bb9_RRzDOLG6>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-b1e7677c-69e1-45e8-b6d9-1cdc256ba8b5)
+
+--------------------------------------------------------------------------------
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume | 15.436    | 26.13        | 39.344       | 47.577       | 49.509    | 27.548    | 100.0%  | 50    |
+| nova.boot_server        | 13.408    | 16.023       | 20.759       | 25.099       | 30.58     | 17.75     | 100.0%  | 50    |
+| nova.delete_server      | 2.452     | 4.728        | 5.029        | 6.303        | 7.062     | 4.205     | 98.0%   | 50    |
+| total                   | 35.941    | 46.606       | 65.052       | 76.765       | 81.526    | 49.504    | 98.0%   | 50    |
+|  -> duration            | 34.941    | 45.606       | 64.052       | 75.765       | 80.526    | 48.504    | 98.0%   | 50    |
+|  -> idle_duration       | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 98.0%   | 50    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 509.501171
+Full duration: 523.520381
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report bfa87348-5ee6-42af-a1d9-2e85e7ae0dca --out output.html
+
+* To generate a JUnit report, run:
+	rally task export bfa87348-5ee6-42af-a1d9-2e85e7ae0dca --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report bfa87348-5ee6-42af-a1d9-2e85e7ae0dca --json --out output.json
+
+At least one workload did not pass SLA criteria.
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NovaServers.boot_server_attach_created_volume_and_live_migrate": [
+        {
+            "args": {
+                "size": 20,
+                "block_migration": false,
+                "image": {
+                    "name": "Ubuntu 14.04 LTS"
+                },
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "boot_server_kwargs": {},
+                "create_volume_kwargs": {}
+            },
+            "runner": {
+                "type": "constant",
+                "times": 2,
+                "concurrency": 1
+            },
+            "context": {
+                "users": {
+                    "tenants": 2,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  3be4e482-9890-4f61-831c-34a77d4cfdcc: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 3be4e482-9890-4f61-831c-34a77d4cfdcc
+2018-06-28 21:08:41.061 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Starting:  Task validation.
+2018-06-28 21:08:41.072 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Starting:  Task validation of syntax.
+2018-06-28 21:08:41.088 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Completed: Task validation of syntax.
+2018-06-28 21:08:41.088 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Starting:  Task validation of required platforms.
+2018-06-28 21:08:41.096 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Completed: Task validation of required platforms.
+2018-06-28 21:08:41.096 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Starting:  Task validation of semantic.
+2018-06-28 21:08:44.131 12077 INFO rally.task.context [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Context users@openstack setup()  finished in 2.34 sec
+2018-06-28 21:08:45.523 12077 INFO rally.task.context [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Context users@openstack cleanup() started
+2018-06-28 21:08:48.866 12077 INFO rally.task.context [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Context users@openstack cleanup() finished in 3.34 sec
+2018-06-28 21:08:48.867 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Completed: Task validation of semantic.
+2018-06-28 21:08:48.867 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Completed: Task validation.
+2018-06-28 21:08:48.868 12077 INFO rally.api [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc input file is valid.
+2018-06-28 21:08:48.868 12077 INFO rally.api [-] Run Task 3be4e482-9890-4f61-831c-34a77d4cfdcc against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:08:48.868 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Starting:  Running task.
+2018-06-28 21:08:48.917 12077 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=3f41b469-fcac-4f91-988f-1cb93bd54370)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_server_attach_created_volume_and_live_migrate", 
+         "description": "Create a VM, attach a volume to it and live migrate.", 
+         "scenario": {
+            "NovaServers.boot_server_attach_created_volume_and_live_migrate": {
+               "size": 20, 
+               "block_migration": false, 
+               "image": {
+                  "name": "Ubuntu 14.04 LTS"
+               }, 
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "boot_server_kwargs": {}, 
+               "create_volume_kwargs": {}
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 2, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 2, 
+               "concurrency": 1
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:08:51.371 12077 INFO rally.task.context [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Context users@openstack setup()  finished in 2.42 sec
+2018-06-28 21:08:51.371 12077 INFO rally.task.context [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-28 21:08:52.096 12293 INFO rally.task.runner [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | ITER: 1 START
+2018-06-28 21:09:25.013 12293 INFO rally.task.runner [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | ITER: 1 END: Error GetResourceErrorStatus: Resource <Server: s_rally_3f41b469_IMZpZwFz> has ERROR status.
+ Fault: n/a
+2018-06-28 21:09:25.018 12293 INFO rally.task.runner [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | ITER: 2 START
+2018-06-28 21:10:05.792 12293 INFO rally.task.runner [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | ITER: 2 END: Error GetResourceErrorStatus: Resource <Server: s_rally_3f41b469_GNwS4gBy> has ERROR status.
+ Fault: n/a
+2018-06-28 21:10:05.815 12077 INFO rally.task.context [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Context cleanup@openstack cleanup() started
+2018-06-28 21:10:20.459 12077 WARNING rally.plugins.openstack.cleanup.manager [-] Resource deletion failed, max retries exceeded for cinder.volumes: 35b891af-f420-4191-aefe-235f5561d6f0. Reason: Invalid volume: Volume status must be available or error or error_restoring or error_extending or error_managing and must not be migrating, attached, belong to a group, have snapshots or be disassociated from snapshots after volume transfer. (HTTP 400) (Request-ID: req-997b82d6-110a-4fa5-bca6-2ee681d5d4fe): BadRequest: Invalid volume: Volume status must be available or error or error_restoring or error_extending or error_managing and must not be migrating, attached, belong to a group, have snapshots or be disassociated from snapshots after volume transfer. (HTTP 400) (Request-ID: req-997b82d6-110a-4fa5-bca6-2ee681d5d4fe)
+2018-06-28 21:10:20.498 12077 WARNING rally.plugins.openstack.cleanup.manager [-] Resource deletion failed, max retries exceeded for cinder.volumes: 49301c00-a4e0-4618-86f0-9cb903390d38. Reason: Invalid volume: Volume status must be available or error or error_restoring or error_extending or error_managing and must not be migrating, attached, belong to a group, have snapshots or be disassociated from snapshots after volume transfer. (HTTP 400) (Request-ID: req-2412e610-3b69-4313-9496-a37ed2c4c087): BadRequest: Invalid volume: Volume status must be available or error or error_restoring or error_extending or error_managing and must not be migrating, attached, belong to a group, have snapshots or be disassociated from snapshots after volume transfer. (HTTP 400) (Request-ID: req-2412e610-3b69-4313-9496-a37ed2c4c087)
+2018-06-28 21:10:20.499 12077 INFO rally.task.context [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Context cleanup@openstack cleanup() finished in 14.68 sec
+2018-06-28 21:10:20.499 12077 INFO rally.task.context [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Context users@openstack cleanup() started
+2018-06-28 21:10:24.538 12077 INFO rally.task.context [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Context users@openstack cleanup() finished in 4.04 sec
+2018-06-28 21:10:25.496 12077 INFO rally.task.engine [-] Load duration is: 72.691061
+2018-06-28 21:10:25.497 12077 INFO rally.task.engine [-] Full runner duration is: 73.736436
+2018-06-28 21:10:25.497 12077 INFO rally.task.engine [-] Full duration is: 95.612676
+2018-06-28 21:10:25.566 12077 INFO rally.task.engine [-] Task 3be4e482-9890-4f61-831c-34a77d4cfdcc | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 3be4e482-9890-4f61-831c-34a77d4cfdcc: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_server_attach_created_volume_and_live_migrate
+args position 0
+args values:
+{
+  "runner": {
+    "times": 2, 
+    "concurrency": 1
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 2, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "size": 20, 
+    "block_migration": false, 
+    "image": {
+      "name": "Ubuntu 14.04 LTS"
+    }, 
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "boot_server_kwargs": {}, 
+    "create_volume_kwargs": {}
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 3be4e482-9890-4f61-831c-34a77d4cfdcc has 2 error(s)
+--------------------------------------------------------------------------------
+
+GetResourceErrorStatus: Resource <Server: s_rally_3f41b469_IMZpZwFz> has ERROR status.
+ Fault: n/a
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 831, in run
+    self._live_migrate(server, block_migration, disk_over_commit)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 760, in _live_migrate
+    CONF.openstack.nova_server_live_migrate_poll_interval)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 90, in _get_from_manager
+    fault=getattr(res, "fault", "n/a"))
+GetResourceErrorStatus: Resource <Server: s_rally_3f41b469_IMZpZwFz> has ERROR status.
+ Fault: n/a
+
+--------------------------------------------------------------------------------
+GetResourceErrorStatus: Resource <Server: s_rally_3f41b469_GNwS4gBy> has ERROR status.
+ Fault: n/a
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 831, in run
+    self._live_migrate(server, block_migration, disk_over_commit)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 760, in _live_migrate
+    CONF.openstack.nova_server_live_migrate_poll_interval)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 90, in _get_from_manager
+    fault=getattr(res, "fault", "n/a"))
+GetResourceErrorStatus: Resource <Server: s_rally_3f41b469_GNwS4gBy> has ERROR status.
+ Fault: n/a
+
+--------------------------------------------------------------------------------
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server        | 20.332    | 23.926       | 26.801       | 27.16        | 27.519    | 23.926    | 100.0%  | 2     |
+| cinder_v2.create_volume | 2.504     | 2.526        | 2.544        | 2.546        | 2.548     | 2.526     | 100.0%  | 2     |
+| nova.attach_volume      | 3.53      | 3.764        | 3.951        | 3.975        | 3.998     | 3.764     | 100.0%  | 2     |
+| nova.live_migrate       | 6.498     | 6.624        | 6.725        | 6.737        | 6.75      | 6.624     | 0.0%    | 2     |
+| total                   | 32.91     | 36.841       | 39.986       | 40.379       | 40.772    | 36.841    | 0.0%    | 2     |
+|  -> duration            | 31.91     | 35.841       | 38.986       | 39.379       | 39.772    | 35.841    | 0.0%    | 2     |
+|  -> idle_duration       | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 0.0%    | 2     |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 72.691061
+Full duration: 95.612676
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 3be4e482-9890-4f61-831c-34a77d4cfdcc --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 3be4e482-9890-4f61-831c-34a77d4cfdcc --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 3be4e482-9890-4f61-831c-34a77d4cfdcc --json --out output.json
+
+At least one workload did not pass SLA criteria.
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NovaServers.boot_server_from_volume_and_delete": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "image": {
+                    "name": "CentOS 7"
+                },
+                "volume_size": 50,
+                "volume_type": "",
+                "force_delete": false
+            },
+            "runner": {
+                "type": "constant",
+                "times": 50,
+                "concurrency": 5
+            },
+            "context": {
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  49eb56c3-9c41-4577-af75-1b40c9dfe3f7: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 49eb56c3-9c41-4577-af75-1b40c9dfe3f7
+2018-06-28 21:10:27.470 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Starting:  Task validation.
+2018-06-28 21:10:27.478 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Starting:  Task validation of syntax.
+2018-06-28 21:10:27.489 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Completed: Task validation of syntax.
+2018-06-28 21:10:27.490 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Starting:  Task validation of required platforms.
+2018-06-28 21:10:27.495 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Completed: Task validation of required platforms.
+2018-06-28 21:10:27.495 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Starting:  Task validation of semantic.
+2018-06-28 21:10:30.655 12747 INFO rally.task.context [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Context users@openstack setup()  finished in 2.52 sec
+2018-06-28 21:10:32.080 12747 INFO rally.task.context [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Context users@openstack cleanup() started
+2018-06-28 21:10:35.477 12747 INFO rally.task.context [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Context users@openstack cleanup() finished in 3.40 sec
+2018-06-28 21:10:35.477 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Completed: Task validation of semantic.
+2018-06-28 21:10:35.477 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Completed: Task validation.
+2018-06-28 21:10:35.478 12747 INFO rally.api [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 input file is valid.
+2018-06-28 21:10:35.478 12747 INFO rally.api [-] Run Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:10:35.478 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Starting:  Running task.
+2018-06-28 21:10:35.516 12747 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=6e6d62a9-5ce5-4837-9503-23f5845d2d70)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_server_from_volume_and_delete", 
+         "description": "Boot a server from volume and then delete it.", 
+         "scenario": {
+            "NovaServers.boot_server_from_volume_and_delete": {
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "image": {
+                  "name": "CentOS 7"
+               }, 
+               "volume_size": 50, 
+               "volume_type": "", 
+               "force_delete": false
+            }
+         }, 
+         "contexts": {}, 
+         "runner": {
+            "constant": {
+               "times": 50, 
+               "concurrency": 5
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:10:38.063 12747 INFO rally.task.context [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Context users@openstack setup()  finished in 2.52 sec
+2018-06-28 21:10:38.063 12747 INFO rally.task.context [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-28 21:10:38.917 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 1 START
+2018-06-28 21:10:38.923 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 2 START
+2018-06-28 21:10:38.926 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 4 START
+2018-06-28 21:10:38.927 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 3 START
+2018-06-28 21:10:38.931 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 5 START
+2018-06-28 21:11:20.471 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 3 END: Error ClientException: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-af1d0b70-173b-4151-ae1b-25e40f5bb12f)
+2018-06-28 21:11:20.477 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 6 START
+2018-06-28 21:11:22.248 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 5 END: Error ClientException: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-7e36090a-7d46-4064-b92a-858cf5f86e10)
+2018-06-28 21:11:22.252 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 7 START
+2018-06-28 21:11:56.671 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 1 END: Error GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_RObpHnPI>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-49b00d7d-1dae-4f11-966a-d36ca2e892e2)
+2018-06-28 21:11:56.677 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 8 START
+2018-06-28 21:11:58.327 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 2 END: Error GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_Mwmi7LGQ>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-e6f3b6e8-ee07-4224-85be-0fd72c3ca82a)
+2018-06-28 21:11:58.332 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 9 START
+2018-06-28 21:12:48.829 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 6 END: Error GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_rjZ0EGLf>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-f9694f2b-082b-49a3-920c-3b076b2fc9d5)
+2018-06-28 21:12:48.833 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 10 START
+2018-06-28 21:12:49.465 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 7 END: Error GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_GyDwcFpx>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-589606be-262e-4b99-844d-39cda3eef109)
+2018-06-28 21:12:49.470 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 11 START
+2018-06-28 21:13:38.620 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 9 END: OK
+2018-06-28 21:13:38.625 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 12 START
+2018-06-28 21:13:40.974 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 8 END: OK
+2018-06-28 21:13:40.978 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 13 START
+2018-06-28 21:14:15.404 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 11 END: OK
+2018-06-28 21:14:15.409 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 14 START
+2018-06-28 21:14:19.267 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 10 END: OK
+2018-06-28 21:14:19.271 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 15 START
+2018-06-28 21:14:29.553 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 13 END: OK
+2018-06-28 21:14:29.557 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 16 START
+2018-06-28 21:14:34.751 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 12 END: OK
+2018-06-28 21:14:34.756 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 17 START
+2018-06-28 21:14:58.363 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 14 END: OK
+2018-06-28 21:14:58.368 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 18 START
+2018-06-28 21:15:11.182 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 15 END: OK
+2018-06-28 21:15:11.185 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 19 START
+2018-06-28 21:15:16.748 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 16 END: OK
+2018-06-28 21:15:16.753 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 20 START
+2018-06-28 21:15:27.616 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 17 END: OK
+2018-06-28 21:15:27.620 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 21 START
+2018-06-28 21:15:42.063 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 18 END: OK
+2018-06-28 21:15:42.068 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 22 START
+2018-06-28 21:15:59.634 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 20 END: OK
+2018-06-28 21:15:59.638 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 23 START
+2018-06-28 21:16:12.131 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 21 END: OK
+2018-06-28 21:16:12.135 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 24 START
+2018-06-28 21:16:24.813 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 22 END: OK
+2018-06-28 21:16:24.818 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 25 START
+2018-06-28 21:16:42.178 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 23 END: OK
+2018-06-28 21:16:42.182 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 26 START
+2018-06-28 21:16:54.357 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 24 END: OK
+2018-06-28 21:16:54.362 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 27 START
+2018-06-28 21:17:07.528 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 25 END: OK
+2018-06-28 21:17:07.532 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 28 START
+2018-06-28 21:17:36.874 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 27 END: OK
+2018-06-28 21:17:36.878 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 29 START
+2018-06-28 21:17:48.222 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 28 END: OK
+2018-06-28 21:17:48.226 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 30 START
+2018-06-28 21:18:17.629 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 29 END: OK
+2018-06-28 21:18:17.634 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 31 START
+2018-06-28 21:18:33.965 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 30 END: OK
+2018-06-28 21:18:33.968 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 32 START
+2018-06-28 21:19:00.363 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 31 END: OK
+2018-06-28 21:19:00.366 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 33 START
+2018-06-28 21:19:16.721 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 32 END: OK
+2018-06-28 21:19:16.725 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 34 START
+2018-06-28 21:19:42.597 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 33 END: OK
+2018-06-28 21:19:42.601 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 35 START
+2018-06-28 21:19:57.156 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 34 END: OK
+2018-06-28 21:19:57.159 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 36 START
+2018-06-28 21:20:27.324 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 35 END: OK
+2018-06-28 21:20:27.328 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 37 START
+2018-06-28 21:20:39.511 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 36 END: OK
+2018-06-28 21:20:39.515 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 38 START
+2018-06-28 21:20:42.511 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 4 END: Error TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_jTqmJtts:83111096-4cd5-4904-b0c7-05767ed7887e to become ('AVAILABLE') current status ERROR
+2018-06-28 21:20:42.516 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 39 START
+2018-06-28 21:21:14.101 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 37 END: OK
+2018-06-28 21:21:14.104 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 40 START
+2018-06-28 21:21:33.061 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 38 END: OK
+2018-06-28 21:21:33.064 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 41 START
+2018-06-28 21:21:34.446 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 39 END: OK
+2018-06-28 21:21:34.451 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 42 START
+2018-06-28 21:22:02.537 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 40 END: OK
+2018-06-28 21:22:02.541 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 43 START
+2018-06-28 21:22:18.027 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 42 END: OK
+2018-06-28 21:22:18.031 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 44 START
+2018-06-28 21:22:50.121 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 43 END: OK
+2018-06-28 21:22:50.125 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 45 START
+2018-06-28 21:23:07.375 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 44 END: OK
+2018-06-28 21:23:07.379 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 46 START
+2018-06-28 21:23:35.321 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 45 END: OK
+2018-06-28 21:23:35.325 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 47 START
+2018-06-28 21:23:50.477 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 46 END: OK
+2018-06-28 21:23:50.481 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 48 START
+2018-06-28 21:24:17.857 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 47 END: OK
+2018-06-28 21:24:17.860 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 49 START
+2018-06-28 21:24:33.376 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 48 END: OK
+2018-06-28 21:24:33.380 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 50 START
+2018-06-28 21:25:03.420 12942 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 49 END: OK
+2018-06-28 21:25:15.880 12943 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 50 END: OK
+2018-06-28 21:25:15.983 12946 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 19 END: Error TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_xXen53p6:c6589031-5dcc-42de-a314-020489c55c1c to become ('AVAILABLE') current status ERROR
+2018-06-28 21:26:46.245 12941 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 26 END: Error TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_GpH1aQCh:943db5c3-d409-4c79-bfca-59a194530fea to become ('AVAILABLE') current status ERROR
+2018-06-28 21:31:37.038 12949 INFO rally.task.runner [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | ITER: 41 END: Error TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_NbJMrOzF:4a21891a-7f3d-4174-b535-37ebd57c443c to become ('AVAILABLE') current status ERROR
+2018-06-28 21:31:37.067 12747 INFO rally.task.context [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Context cleanup@openstack cleanup() started
+2018-06-28 21:31:50.345 12747 INFO rally.task.context [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Context cleanup@openstack cleanup() finished in 13.28 sec
+2018-06-28 21:31:50.345 12747 INFO rally.task.context [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Context users@openstack cleanup() started
+2018-06-28 21:31:53.533 12747 INFO rally.task.context [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Context users@openstack cleanup() finished in 3.19 sec
+2018-06-28 21:31:54.054 12747 INFO rally.task.engine [-] Load duration is: 1258.116347
+2018-06-28 21:31:54.054 12747 INFO rally.task.engine [-] Full runner duration is: 1258.165557
+2018-06-28 21:31:54.055 12747 INFO rally.task.engine [-] Full duration is: 1278.012216
+2018-06-28 21:31:54.150 12747 INFO rally.task.engine [-] Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_server_from_volume_and_delete
+args position 0
+args values:
+{
+  "runner": {
+    "times": 50, 
+    "concurrency": 5
+  }, 
+  "contexts": {}, 
+  "args": {
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "image": {
+      "name": "CentOS 7"
+    }, 
+    "volume_size": 50, 
+    "volume_type": "", 
+    "force_delete": false
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 has 10 error(s)
+--------------------------------------------------------------------------------
+
+GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_RObpHnPI>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-49b00d7d-1dae-4f11-966a-d36ca2e892e2)
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 193, in run
+    **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 87, in _boot_server
+    check_interval=CONF.openstack.nova_server_boot_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 80, in _get_from_manager
+    raise exceptions.GetResourceFailure(resource=resource, err=e)
+GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_RObpHnPI>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-49b00d7d-1dae-4f11-966a-d36ca2e892e2)
+
+--------------------------------------------------------------------------------
+GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_Mwmi7LGQ>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-e6f3b6e8-ee07-4224-85be-0fd72c3ca82a)
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 193, in run
+    **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 87, in _boot_server
+    check_interval=CONF.openstack.nova_server_boot_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 80, in _get_from_manager
+    raise exceptions.GetResourceFailure(resource=resource, err=e)
+GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_Mwmi7LGQ>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-e6f3b6e8-ee07-4224-85be-0fd72c3ca82a)
+
+--------------------------------------------------------------------------------
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_jTqmJtts:83111096-4cd5-4904-b0c7-05767ed7887e to become ('AVAILABLE') current status ERROR
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 189, in run
+    volume_type=volume_type)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/block.py", line 77, in create_volume
+    source_replica=source_replica, multiattach=multiattach)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 274, in create_volume
+    source_replica=source_replica, multiattach=multiattach))
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 83, in create_volume
+    return self._wait_available_volume(volume)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_common.py", line 56, in _wait_available_volume
+    check_interval=CONF.openstack.cinder_volume_create_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 253, in wait_for_status
+    timeout=timeout)
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_jTqmJtts:83111096-4cd5-4904-b0c7-05767ed7887e to become ('AVAILABLE') current status ERROR
+
+--------------------------------------------------------------------------------
+ClientException: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-af1d0b70-173b-4151-ae1b-25e40f5bb12f)
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 193, in run
+    **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 79, in _boot_server
+    server_name, image, flavor, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/novaclient/v2/servers.py", line 1403, in create
+    **boot_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/novaclient/v2/servers.py", line 802, in _boot
+    return_raw=return_raw, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/novaclient/base.py", line 361, in _create
+    resp, body = self.api.client.post(url, body=body)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/keystoneauth1/adapter.py", line 310, in post
+    return self.request(url, 'POST', **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/novaclient/client.py", line 83, in request
+    raise exceptions.from_response(resp, body, url, method)
+ClientException: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-af1d0b70-173b-4151-ae1b-25e40f5bb12f)
+
+--------------------------------------------------------------------------------
+ClientException: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-7e36090a-7d46-4064-b92a-858cf5f86e10)
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 193, in run
+    **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 79, in _boot_server
+    server_name, image, flavor, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/novaclient/v2/servers.py", line 1403, in create
+    **boot_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/novaclient/v2/servers.py", line 802, in _boot
+    return_raw=return_raw, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/novaclient/base.py", line 361, in _create
+    resp, body = self.api.client.post(url, body=body)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/keystoneauth1/adapter.py", line 310, in post
+    return self.request(url, 'POST', **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/novaclient/client.py", line 83, in request
+    raise exceptions.from_response(resp, body, url, method)
+ClientException: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-7e36090a-7d46-4064-b92a-858cf5f86e10)
+
+--------------------------------------------------------------------------------
+GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_rjZ0EGLf>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-f9694f2b-082b-49a3-920c-3b076b2fc9d5)
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 193, in run
+    **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 87, in _boot_server
+    check_interval=CONF.openstack.nova_server_boot_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 80, in _get_from_manager
+    raise exceptions.GetResourceFailure(resource=resource, err=e)
+GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_rjZ0EGLf>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-f9694f2b-082b-49a3-920c-3b076b2fc9d5)
+
+--------------------------------------------------------------------------------
+GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_GyDwcFpx>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-589606be-262e-4b99-844d-39cda3eef109)
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 193, in run
+    **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 87, in _boot_server
+    check_interval=CONF.openstack.nova_server_boot_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 80, in _get_from_manager
+    raise exceptions.GetResourceFailure(resource=resource, err=e)
+GetResourceFailure: Failed to get the resource <Server: s_rally_6e6d62a9_GyDwcFpx>: Unexpected API Error. Please report this at http://bugs.launchpad.net/nova/ and attach the Nova API log if possible.
+<class 'oslo_db.exception.DBError'> (HTTP 500) (Request-ID: req-589606be-262e-4b99-844d-39cda3eef109)
+
+--------------------------------------------------------------------------------
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_xXen53p6:c6589031-5dcc-42de-a314-020489c55c1c to become ('AVAILABLE') current status ERROR
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 189, in run
+    volume_type=volume_type)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/block.py", line 77, in create_volume
+    source_replica=source_replica, multiattach=multiattach)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 274, in create_volume
+    source_replica=source_replica, multiattach=multiattach))
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 83, in create_volume
+    return self._wait_available_volume(volume)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_common.py", line 56, in _wait_available_volume
+    check_interval=CONF.openstack.cinder_volume_create_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 253, in wait_for_status
+    timeout=timeout)
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_xXen53p6:c6589031-5dcc-42de-a314-020489c55c1c to become ('AVAILABLE') current status ERROR
+
+--------------------------------------------------------------------------------
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_GpH1aQCh:943db5c3-d409-4c79-bfca-59a194530fea to become ('AVAILABLE') current status ERROR
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 189, in run
+    volume_type=volume_type)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/block.py", line 77, in create_volume
+    source_replica=source_replica, multiattach=multiattach)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 274, in create_volume
+    source_replica=source_replica, multiattach=multiattach))
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 83, in create_volume
+    return self._wait_available_volume(volume)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_common.py", line 56, in _wait_available_volume
+    check_interval=CONF.openstack.cinder_volume_create_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 253, in wait_for_status
+    timeout=timeout)
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_GpH1aQCh:943db5c3-d409-4c79-bfca-59a194530fea to become ('AVAILABLE') current status ERROR
+
+--------------------------------------------------------------------------------
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_NbJMrOzF:4a21891a-7f3d-4174-b535-37ebd57c443c to become ('AVAILABLE') current status ERROR
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 189, in run
+    volume_type=volume_type)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/block.py", line 77, in create_volume
+    source_replica=source_replica, multiattach=multiattach)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 274, in create_volume
+    source_replica=source_replica, multiattach=multiattach))
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/service.py", line 116, in wrapper
+    return func(instance, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_v2.py", line 83, in create_volume
+    return self._wait_available_volume(volume)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/services/storage/cinder_common.py", line 56, in _wait_available_volume
+    check_interval=CONF.openstack.cinder_volume_create_poll_interval
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 253, in wait_for_status
+    timeout=timeout)
+TimeoutException: Rally tired waiting 600.00 seconds for Volume s_rally_6e6d62a9_NbJMrOzF:4a21891a-7f3d-4174-b535-37ebd57c443c to become ('AVAILABLE') current status ERROR
+
+--------------------------------------------------------------------------------
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume | 19.714    | 25.047       | 77.52        | 603.794      | 604.794   | 77.996    | 92.0%   | 50    |
+| nova.boot_server        | 0.074     | 16.819       | 22.781       | 24.113       | 28.531    | 17.598    | 87.0%   | 46    |
+| nova.delete_server      | 2.455     | 2.618        | 4.698        | 4.868        | 6.768     | 3.358     | 100.0%  | 40    |
+| total                   | 40.429    | 45.376       | 100.686      | 603.794      | 604.794   | 96.872    | 80.0%   | 50    |
+|  -> duration            | 39.429    | 44.376       | 99.686       | 603.794      | 604.794   | 95.992    | 80.0%   | 50    |
+|  -> idle_duration       | 0.0       | 1.0          | 1.0          | 1.0          | 1.0       | 0.88      | 80.0%   | 50    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 1258.116347
+Full duration: 1278.012216
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 49eb56c3-9c41-4577-af75-1b40c9dfe3f7 --json --out output.json
+
+At least one workload did not pass SLA criteria.
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NeutronNetworks.create_and_delete_subnets": [
+        {
+            "args": {
+                "network_create_args": {},
+                "subnet_create_args": {},
+                "subnet_cidr_start": "1.1.0.0/30",
+                "subnets_per_network": 2
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 10
+            },
+            "context": {
+                "network": {},
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1,
+                        "subnet": -1
+                    }
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  40f01455-6c63-4e8c-9d90-5477b3376667: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 40f01455-6c63-4e8c-9d90-5477b3376667
+2018-06-28 21:31:56.133 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Starting:  Task validation.
+2018-06-28 21:31:56.145 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Starting:  Task validation of syntax.
+2018-06-28 21:31:56.167 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Completed: Task validation of syntax.
+2018-06-28 21:31:56.168 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Starting:  Task validation of required platforms.
+2018-06-28 21:31:56.175 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Completed: Task validation of required platforms.
+2018-06-28 21:31:56.176 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Starting:  Task validation of semantic.
+2018-06-28 21:31:59.060 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context users@openstack setup()  finished in 2.18 sec
+2018-06-28 21:31:59.454 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context users@openstack cleanup() started
+2018-06-28 21:32:02.683 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context users@openstack cleanup() finished in 3.23 sec
+2018-06-28 21:32:02.684 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Completed: Task validation of semantic.
+2018-06-28 21:32:02.684 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Completed: Task validation.
+2018-06-28 21:32:02.685 17035 INFO rally.api [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 input file is valid.
+2018-06-28 21:32:02.685 17035 INFO rally.api [-] Run Task 40f01455-6c63-4e8c-9d90-5477b3376667 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:32:02.686 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Starting:  Running task.
+2018-06-28 21:32:02.720 17035 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=0b0166bf-70b8-479f-b172-4a8c7f1ac31e)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_delete_subnets", 
+         "description": "Create and delete a given number of subnets.", 
+         "scenario": {
+            "NeutronNetworks.create_and_delete_subnets": {
+               "network_create_args": {}, 
+               "subnet_create_args": {}, 
+               "subnet_cidr_start": "1.1.0.0/30", 
+               "subnets_per_network": 2
+            }
+         }, 
+         "contexts": {
+            "network": {}, 
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1, 
+                  "subnet": -1
+               }
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:32:05.553 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context users@openstack setup()  finished in 2.80 sec
+2018-06-28 21:32:06.205 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context quotas@openstack setup()  finished in 0.65 sec
+2018-06-28 21:32:21.923 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context network@openstack setup()  finished in 15.72 sec
+2018-06-28 21:32:21.924 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context cleanup@openstack setup()  finished in 0.05 msec
+2018-06-28 21:32:21.951 17435 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 1 START
+2018-06-28 21:32:21.953 17436 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 2 START
+2018-06-28 21:32:21.955 17438 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 3 START
+2018-06-28 21:32:21.958 17439 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 4 START
+2018-06-28 21:32:21.962 17440 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 5 START
+2018-06-28 21:32:21.963 17444 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 6 START
+2018-06-28 21:32:21.965 17448 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 7 START
+2018-06-28 21:32:21.968 17451 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 8 START
+2018-06-28 21:32:21.968 17452 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 9 START
+2018-06-28 21:32:21.976 17457 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 10 START
+2018-06-28 21:32:26.628 17457 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 10 END: OK
+2018-06-28 21:32:27.246 17440 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 5 END: OK
+2018-06-28 21:32:27.771 17439 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 4 END: OK
+2018-06-28 21:32:28.000 17444 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 6 END: OK
+2018-06-28 21:32:28.184 17448 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 7 END: OK
+2018-06-28 21:32:29.044 17451 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 8 END: OK
+2018-06-28 21:32:29.449 17452 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 9 END: OK
+2018-06-28 21:32:29.505 17436 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 2 END: OK
+2018-06-28 21:32:30.864 17438 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 3 END: OK
+2018-06-28 21:32:33.613 17435 INFO rally.task.runner [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | ITER: 1 END: OK
+2018-06-28 21:32:33.640 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context cleanup@openstack cleanup() started
+2018-06-28 21:32:52.611 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context cleanup@openstack cleanup() finished in 18.97 sec
+2018-06-28 21:32:52.612 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context network@openstack cleanup() started
+2018-06-28 21:33:14.352 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context network@openstack cleanup() finished in 21.74 sec
+2018-06-28 21:33:14.352 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context quotas@openstack cleanup() started
+2018-06-28 21:33:14.423 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context quotas@openstack cleanup() finished in 70.59 msec
+2018-06-28 21:33:14.423 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context users@openstack cleanup() started
+2018-06-28 21:33:19.320 17035 INFO rally.task.context [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Context users@openstack cleanup() finished in 4.90 sec
+2018-06-28 21:33:21.254 17035 INFO rally.task.engine [-] Load duration is: 11.658939
+2018-06-28 21:33:21.254 17035 INFO rally.task.engine [-] Full runner duration is: 11.708703
+2018-06-28 21:33:21.255 17035 INFO rally.task.engine [-] Full duration is: 76.593634
+2018-06-28 21:33:21.318 17035 INFO rally.task.engine [-] Task 40f01455-6c63-4e8c-9d90-5477b3376667 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 40f01455-6c63-4e8c-9d90-5477b3376667: finished
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_delete_subnets
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "network": {}, 
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1, 
+        "subnet": -1
+      }
+    }
+  }, 
+  "args": {
+    "network_create_args": {}, 
+    "subnet_create_args": {}, 
+    "subnet_cidr_start": "1.1.0.0/30", 
+    "subnets_per_network": 2
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 40f01455-6c63-4e8c-9d90-5477b3376667 has 0 error(s)
+--------------------------------------------------------------------------------
+
++-------------------------------------------------------------------------------------------------------------------------------+
+|                                                     Response Times (sec)                                                      |
++----------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                     | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++----------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_subnet (x2) | 2.084     | 3.263        | 4.762        | 5.644        | 6.526     | 3.553     | 100.0%  | 10    |
+| neutron.delete_subnet (x2) | 2.32      | 2.96         | 5.181        | 6.137        | 7.092     | 3.513     | 100.0%  | 10    |
+| total                      | 4.651     | 6.646        | 9.181        | 10.42        | 11.659    | 7.066     | 100.0%  | 10    |
+|  -> duration               | 4.651     | 6.646        | 9.181        | 10.42        | 11.659    | 7.066     | 100.0%  | 10    |
+|  -> idle_duration          | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 10    |
++----------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 11.658939
+Full duration: 76.593634
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 40f01455-6c63-4e8c-9d90-5477b3376667 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 40f01455-6c63-4e8c-9d90-5477b3376667 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 40f01455-6c63-4e8c-9d90-5477b3376667 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NeutronNetworks.create_and_list_networks": [
+        {
+            "args": {
+                "network_create_args": {}
+            },
+            "runner": {
+                "type": "constant",
+                "times": 100,
+                "concurrency": 10
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1
+                    }
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        },
+        {
+            "args": {
+                "network_create_args": {
+                    "provider:network_type": "vxlan"
+                }
+            },
+            "runner": {
+                "type": "constant",
+                "times": 100,
+                "concurrency": 10
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1
+                    }
+                },
+                "roles": ["admin"]
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  3b7a8976-b2ca-41b4-988a-62963a22c503: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 3b7a8976-b2ca-41b4-988a-62963a22c503
+2018-06-28 21:33:23.392 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Starting:  Task validation.
+2018-06-28 21:33:23.402 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Starting:  Task validation of syntax.
+2018-06-28 21:33:23.434 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Completed: Task validation of syntax.
+2018-06-28 21:33:23.435 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Starting:  Task validation of required platforms.
+2018-06-28 21:33:23.446 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Completed: Task validation of required platforms.
+2018-06-28 21:33:23.447 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Starting:  Task validation of semantic.
+2018-06-28 21:33:26.218 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context users@openstack setup()  finished in 2.17 sec
+2018-06-28 21:33:27.031 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context users@openstack cleanup() started
+2018-06-28 21:33:30.348 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context users@openstack cleanup() finished in 3.32 sec
+2018-06-28 21:33:30.349 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Completed: Task validation of semantic.
+2018-06-28 21:33:30.349 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Completed: Task validation.
+2018-06-28 21:33:30.349 18149 INFO rally.api [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 input file is valid.
+2018-06-28 21:33:30.350 18149 INFO rally.api [-] Run Task 3b7a8976-b2ca-41b4-988a-62963a22c503 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:33:30.350 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Starting:  Running task.
+2018-06-28 21:33:30.395 18149 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=14d8d75d-5311-4b92-acde-07937db2d354)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_list_networks", 
+         "description": "Create a network and then list all networks.", 
+         "scenario": {
+            "NeutronNetworks.create_and_list_networks": {
+               "network_create_args": {}
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1
+               }
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 100, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:33:33.204 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context users@openstack setup()  finished in 2.78 sec
+2018-06-28 21:33:33.823 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context quotas@openstack setup()  finished in 0.62 sec
+2018-06-28 21:33:33.824 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-28 21:33:33.858 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 1 START
+2018-06-28 21:33:33.860 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 2 START
+2018-06-28 21:33:33.861 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 3 START
+2018-06-28 21:33:33.861 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 4 START
+2018-06-28 21:33:33.865 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 5 START
+2018-06-28 21:33:33.869 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 6 START
+2018-06-28 21:33:33.871 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 8 START
+2018-06-28 21:33:33.872 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 9 START
+2018-06-28 21:33:33.872 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 7 START
+2018-06-28 21:33:33.872 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 10 START
+2018-06-28 21:33:34.927 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 6 END: OK
+2018-06-28 21:33:34.934 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 11 START
+2018-06-28 21:33:34.976 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 7 END: OK
+2018-06-28 21:33:34.981 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 12 START
+2018-06-28 21:33:35.066 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 5 END: OK
+2018-06-28 21:33:35.072 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 13 START
+2018-06-28 21:33:35.133 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 8 END: OK
+2018-06-28 21:33:35.134 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 4 END: OK
+2018-06-28 21:33:35.137 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 14 START
+2018-06-28 21:33:35.138 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 9 END: OK
+2018-06-28 21:33:35.138 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 15 START
+2018-06-28 21:33:35.142 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 16 START
+2018-06-28 21:33:35.236 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 3 END: OK
+2018-06-28 21:33:35.242 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 17 START
+2018-06-28 21:33:35.242 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 2 END: OK
+2018-06-28 21:33:35.247 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 18 START
+2018-06-28 21:33:35.284 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 1 END: OK
+2018-06-28 21:33:35.289 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 19 START
+2018-06-28 21:33:35.425 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 10 END: OK
+2018-06-28 21:33:35.429 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 20 START
+2018-06-28 21:33:35.859 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 11 END: OK
+2018-06-28 21:33:35.864 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 21 START
+2018-06-28 21:33:35.981 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 12 END: OK
+2018-06-28 21:33:35.986 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 22 START
+2018-06-28 21:33:36.000 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 15 END: OK
+2018-06-28 21:33:36.005 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 23 START
+2018-06-28 21:33:36.124 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 13 END: OK
+2018-06-28 21:33:36.128 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 24 START
+2018-06-28 21:33:36.146 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 16 END: OK
+2018-06-28 21:33:36.150 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 25 START
+2018-06-28 21:33:36.209 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 14 END: OK
+2018-06-28 21:33:36.214 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 26 START
+2018-06-28 21:33:36.254 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 18 END: OK
+2018-06-28 21:33:36.259 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 27 START
+2018-06-28 21:33:36.381 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 19 END: OK
+2018-06-28 21:33:36.385 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 28 START
+2018-06-28 21:33:36.397 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 17 END: OK
+2018-06-28 21:33:36.402 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 29 START
+2018-06-28 21:33:36.410 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 20 END: OK
+2018-06-28 21:33:36.415 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 30 START
+2018-06-28 21:33:36.770 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 21 END: OK
+2018-06-28 21:33:36.775 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 31 START
+2018-06-28 21:33:36.983 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 22 END: OK
+2018-06-28 21:33:36.988 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 32 START
+2018-06-28 21:33:37.103 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 23 END: OK
+2018-06-28 21:33:37.108 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 33 START
+2018-06-28 21:33:37.252 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 25 END: OK
+2018-06-28 21:33:37.257 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 34 START
+2018-06-28 21:33:37.353 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 27 END: OK
+2018-06-28 21:33:37.359 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 35 START
+2018-06-28 21:33:37.373 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 24 END: OK
+2018-06-28 21:33:37.377 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 36 START
+2018-06-28 21:33:37.553 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 30 END: OK
+2018-06-28 21:33:37.558 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 37 START
+2018-06-28 21:33:37.559 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 28 END: OK
+2018-06-28 21:33:37.564 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 38 START
+2018-06-28 21:33:37.604 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 29 END: OK
+2018-06-28 21:33:37.609 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 39 START
+2018-06-28 21:33:37.659 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 26 END: OK
+2018-06-28 21:33:37.664 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 40 START
+2018-06-28 21:33:37.973 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 32 END: OK
+2018-06-28 21:33:37.979 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 41 START
+2018-06-28 21:33:38.120 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 31 END: OK
+2018-06-28 21:33:38.125 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 42 START
+2018-06-28 21:33:38.296 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 34 END: OK
+2018-06-28 21:33:38.302 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 43 START
+2018-06-28 21:33:38.364 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 33 END: OK
+2018-06-28 21:33:38.368 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 44 START
+2018-06-28 21:33:38.421 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 35 END: OK
+2018-06-28 21:33:38.426 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 45 START
+2018-06-28 21:33:38.576 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 36 END: OK
+2018-06-28 21:33:38.581 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 46 START
+2018-06-28 21:33:38.667 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 38 END: OK
+2018-06-28 21:33:38.672 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 47 START
+2018-06-28 21:33:38.678 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 37 END: OK
+2018-06-28 21:33:38.682 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 48 START
+2018-06-28 21:33:38.864 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 39 END: OK
+2018-06-28 21:33:38.869 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 49 START
+2018-06-28 21:33:38.921 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 40 END: OK
+2018-06-28 21:33:38.926 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 50 START
+2018-06-28 21:33:39.246 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 41 END: OK
+2018-06-28 21:33:39.251 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 51 START
+2018-06-28 21:33:39.254 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 42 END: OK
+2018-06-28 21:33:39.259 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 52 START
+2018-06-28 21:33:39.380 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 43 END: OK
+2018-06-28 21:33:39.384 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 53 START
+2018-06-28 21:33:39.532 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 45 END: OK
+2018-06-28 21:33:39.537 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 54 START
+2018-06-28 21:33:39.554 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 44 END: OK
+2018-06-28 21:33:39.558 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 55 START
+2018-06-28 21:33:39.837 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 47 END: OK
+2018-06-28 21:33:39.842 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 56 START
+2018-06-28 21:33:39.855 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 48 END: OK
+2018-06-28 21:33:39.859 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 57 START
+2018-06-28 21:33:39.881 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 46 END: OK
+2018-06-28 21:33:39.885 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 58 START
+2018-06-28 21:33:40.086 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 50 END: OK
+2018-06-28 21:33:40.092 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 59 START
+2018-06-28 21:33:40.338 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 51 END: OK
+2018-06-28 21:33:40.343 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 60 START
+2018-06-28 21:33:40.347 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 49 END: OK
+2018-06-28 21:33:40.353 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 61 START
+2018-06-28 21:33:40.817 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 54 END: OK
+2018-06-28 21:33:40.822 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 62 START
+2018-06-28 21:33:40.850 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 52 END: OK
+2018-06-28 21:33:40.855 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 63 START
+2018-06-28 21:33:40.932 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 55 END: OK
+2018-06-28 21:33:40.938 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 64 START
+2018-06-28 21:33:41.118 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 57 END: OK
+2018-06-28 21:33:41.123 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 65 START
+2018-06-28 21:33:41.129 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 56 END: OK
+2018-06-28 21:33:41.133 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 66 START
+2018-06-28 21:33:41.168 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 58 END: OK
+2018-06-28 21:33:41.173 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 67 START
+2018-06-28 21:33:41.326 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 59 END: OK
+2018-06-28 21:33:41.331 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 68 START
+2018-06-28 21:33:41.391 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 53 END: OK
+2018-06-28 21:33:41.396 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 69 START
+2018-06-28 21:33:41.562 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 60 END: OK
+2018-06-28 21:33:41.567 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 70 START
+2018-06-28 21:33:41.628 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 61 END: OK
+2018-06-28 21:33:41.632 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 71 START
+2018-06-28 21:33:41.968 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 63 END: OK
+2018-06-28 21:33:41.972 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 72 START
+2018-06-28 21:33:42.045 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 62 END: OK
+2018-06-28 21:33:42.049 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 73 START
+2018-06-28 21:33:42.296 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 65 END: OK
+2018-06-28 21:33:42.302 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 74 START
+2018-06-28 21:33:42.332 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 64 END: OK
+2018-06-28 21:33:42.336 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 75 START
+2018-06-28 21:33:42.579 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 68 END: OK
+2018-06-28 21:33:42.583 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 76 START
+2018-06-28 21:33:42.703 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 67 END: OK
+2018-06-28 21:33:42.708 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 77 START
+2018-06-28 21:33:42.785 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 69 END: OK
+2018-06-28 21:33:42.790 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 78 START
+2018-06-28 21:33:42.984 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 70 END: OK
+2018-06-28 21:33:42.990 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 79 START
+2018-06-28 21:33:43.307 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 73 END: OK
+2018-06-28 21:33:43.312 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 80 START
+2018-06-28 21:33:43.318 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 66 END: OK
+2018-06-28 21:33:43.323 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 81 START
+2018-06-28 21:33:43.360 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 72 END: OK
+2018-06-28 21:33:43.365 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 82 START
+2018-06-28 21:33:43.557 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 74 END: OK
+2018-06-28 21:33:43.562 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 83 START
+2018-06-28 21:33:43.884 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 77 END: OK
+2018-06-28 21:33:43.889 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 84 START
+2018-06-28 21:33:43.935 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 76 END: OK
+2018-06-28 21:33:43.938 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 71 END: OK
+2018-06-28 21:33:43.940 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 85 START
+2018-06-28 21:33:43.943 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 86 START
+2018-06-28 21:33:44.332 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 79 END: OK
+2018-06-28 21:33:44.336 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 87 START
+2018-06-28 21:33:44.612 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 78 END: OK
+2018-06-28 21:33:44.614 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 81 END: OK
+2018-06-28 21:33:44.616 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 75 END: OK
+2018-06-28 21:33:44.617 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 88 START
+2018-06-28 21:33:44.619 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 89 START
+2018-06-28 21:33:44.622 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 90 START
+2018-06-28 21:33:44.695 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 82 END: OK
+2018-06-28 21:33:44.699 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 91 START
+2018-06-28 21:33:44.747 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 80 END: OK
+2018-06-28 21:33:44.751 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 92 START
+2018-06-28 21:33:45.046 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 83 END: OK
+2018-06-28 21:33:45.051 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 93 START
+2018-06-28 21:33:45.250 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 85 END: OK
+2018-06-28 21:33:45.254 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 94 START
+2018-06-28 21:33:45.322 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 84 END: OK
+2018-06-28 21:33:45.327 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 95 START
+2018-06-28 21:33:45.575 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 86 END: OK
+2018-06-28 21:33:45.580 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 96 START
+2018-06-28 21:33:45.770 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 87 END: OK
+2018-06-28 21:33:45.775 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 97 START
+2018-06-28 21:33:46.045 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 88 END: OK
+2018-06-28 21:33:46.051 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 98 START
+2018-06-28 21:33:46.069 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 89 END: OK
+2018-06-28 21:33:46.075 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 99 START
+2018-06-28 21:33:46.100 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 90 END: OK
+2018-06-28 21:33:46.105 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 100 START
+2018-06-28 21:33:46.388 18396 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 92 END: OK
+2018-06-28 21:33:46.702 18399 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 95 END: OK
+2018-06-28 21:33:46.772 18407 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 94 END: OK
+2018-06-28 21:33:46.795 18400 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 91 END: OK
+2018-06-28 21:33:47.217 18412 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 93 END: OK
+2018-06-28 21:33:47.331 18398 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 100 END: OK
+2018-06-28 21:33:47.336 18402 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 97 END: OK
+2018-06-28 21:33:47.506 18395 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 99 END: OK
+2018-06-28 21:33:47.628 18397 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 96 END: OK
+2018-06-28 21:33:48.209 18405 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 98 END: OK
+2018-06-28 21:33:48.230 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context cleanup@openstack cleanup() started
+2018-06-28 21:34:18.436 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context cleanup@openstack cleanup() finished in 30.21 sec
+2018-06-28 21:34:18.437 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context quotas@openstack cleanup() started
+2018-06-28 21:34:18.513 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context quotas@openstack cleanup() finished in 76.34 msec
+2018-06-28 21:34:18.514 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context users@openstack cleanup() started
+2018-06-28 21:34:23.288 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context users@openstack cleanup() finished in 4.77 sec
+2018-06-28 21:34:24.824 18149 INFO rally.task.engine [-] Load duration is: 14.347586
+2018-06-28 21:34:24.825 18149 INFO rally.task.engine [-] Full runner duration is: 14.39897
+2018-06-28 21:34:24.825 18149 INFO rally.task.engine [-] Full duration is: 52.886945
+2018-06-28 21:34:25.009 18149 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=09351d3d-b1b7-4511-ac1b-9598fe2d7064)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_list_networks", 
+         "description": "Create a network and then list all networks.", 
+         "scenario": {
+            "NeutronNetworks.create_and_list_networks": {
+               "network_create_args": {
+                  "provider:network_type": "vxlan"
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1
+               }
+            }, 
+            "roles": [
+               "admin"
+            ]
+         }, 
+         "runner": {
+            "constant": {
+               "times": 100, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:34:27.942 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context users@openstack setup()  finished in 2.90 sec
+2018-06-28 21:34:28.532 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context quotas@openstack setup()  finished in 0.59 sec
+2018-06-28 21:34:37.822 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context roles@openstack setup()  finished in 9.29 sec
+2018-06-28 21:34:37.823 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-28 21:34:37.850 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 1 START
+2018-06-28 21:34:37.852 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 2 START
+2018-06-28 21:34:37.854 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 3 START
+2018-06-28 21:34:37.856 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 4 START
+2018-06-28 21:34:37.858 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 5 START
+2018-06-28 21:34:37.863 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 7 START
+2018-06-28 21:34:37.864 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 6 START
+2018-06-28 21:34:37.867 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 8 START
+2018-06-28 21:34:37.874 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 9 START
+2018-06-28 21:34:37.875 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 10 START
+2018-06-28 21:34:39.099 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 5 END: OK
+2018-06-28 21:34:39.105 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 11 START
+2018-06-28 21:34:39.142 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 9 END: OK
+2018-06-28 21:34:39.148 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 12 START
+2018-06-28 21:34:39.250 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 4 END: OK
+2018-06-28 21:34:39.257 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 13 START
+2018-06-28 21:34:39.260 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 6 END: OK
+2018-06-28 21:34:39.265 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 14 START
+2018-06-28 21:34:39.430 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 3 END: OK
+2018-06-28 21:34:39.437 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 15 START
+2018-06-28 21:34:39.438 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 7 END: OK
+2018-06-28 21:34:39.444 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 16 START
+2018-06-28 21:34:39.451 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 2 END: OK
+2018-06-28 21:34:39.452 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 1 END: OK
+2018-06-28 21:34:39.456 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 17 START
+2018-06-28 21:34:39.457 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 18 START
+2018-06-28 21:34:39.501 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 10 END: OK
+2018-06-28 21:34:39.505 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 19 START
+2018-06-28 21:34:39.511 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 8 END: OK
+2018-06-28 21:34:39.516 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 20 START
+2018-06-28 21:34:40.062 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 12 END: OK
+2018-06-28 21:34:40.067 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 21 START
+2018-06-28 21:34:40.191 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 13 END: OK
+2018-06-28 21:34:40.195 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 11 END: OK
+2018-06-28 21:34:40.196 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 22 START
+2018-06-28 21:34:40.200 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 23 START
+2018-06-28 21:34:40.389 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 17 END: OK
+2018-06-28 21:34:40.395 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 24 START
+2018-06-28 21:34:40.413 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 14 END: OK
+2018-06-28 21:34:40.418 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 25 START
+2018-06-28 21:34:40.419 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 19 END: OK
+2018-06-28 21:34:40.424 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 26 START
+2018-06-28 21:34:40.467 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 16 END: OK
+2018-06-28 21:34:40.472 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 27 START
+2018-06-28 21:34:40.490 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 18 END: OK
+2018-06-28 21:34:40.494 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 28 START
+2018-06-28 21:34:40.598 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 20 END: OK
+2018-06-28 21:34:40.603 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 29 START
+2018-06-28 21:34:40.843 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 15 END: OK
+2018-06-28 21:34:40.849 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 30 START
+2018-06-28 21:34:41.072 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 22 END: OK
+2018-06-28 21:34:41.077 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 31 START
+2018-06-28 21:34:41.110 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 23 END: OK
+2018-06-28 21:34:41.116 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 32 START
+2018-06-28 21:34:41.155 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 21 END: OK
+2018-06-28 21:34:41.160 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 33 START
+2018-06-28 21:34:41.385 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 24 END: OK
+2018-06-28 21:34:41.390 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 34 START
+2018-06-28 21:34:41.475 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 25 END: OK
+2018-06-28 21:34:41.480 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 35 START
+2018-06-28 21:34:41.518 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 29 END: OK
+2018-06-28 21:34:41.524 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 36 START
+2018-06-28 21:34:41.531 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 26 END: OK
+2018-06-28 21:34:41.536 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 37 START
+2018-06-28 21:34:41.562 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 27 END: OK
+2018-06-28 21:34:41.566 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 38 START
+2018-06-28 21:34:41.625 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 28 END: OK
+2018-06-28 21:34:41.629 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 39 START
+2018-06-28 21:34:41.789 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 30 END: OK
+2018-06-28 21:34:41.794 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 40 START
+2018-06-28 21:34:42.097 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 33 END: OK
+2018-06-28 21:34:42.103 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 41 START
+2018-06-28 21:34:42.218 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 32 END: OK
+2018-06-28 21:34:42.223 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 42 START
+2018-06-28 21:34:42.456 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 31 END: OK
+2018-06-28 21:34:42.461 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 43 START
+2018-06-28 21:34:42.613 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 38 END: OK
+2018-06-28 21:34:42.618 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 44 START
+2018-06-28 21:34:42.701 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 34 END: OK
+2018-06-28 21:34:42.708 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 45 START
+2018-06-28 21:34:42.715 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 36 END: OK
+2018-06-28 21:34:42.720 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 46 START
+2018-06-28 21:34:42.761 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 35 END: OK
+2018-06-28 21:34:42.766 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 47 START
+2018-06-28 21:34:42.843 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 37 END: OK
+2018-06-28 21:34:42.847 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 48 START
+2018-06-28 21:34:42.923 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 39 END: OK
+2018-06-28 21:34:42.928 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 49 START
+2018-06-28 21:34:43.075 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 41 END: OK
+2018-06-28 21:34:43.080 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 50 START
+2018-06-28 21:34:43.162 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 40 END: OK
+2018-06-28 21:34:43.166 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 51 START
+2018-06-28 21:34:43.458 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 42 END: OK
+2018-06-28 21:34:43.463 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 52 START
+2018-06-28 21:34:43.467 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 43 END: OK
+2018-06-28 21:34:43.472 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 53 START
+2018-06-28 21:34:43.581 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 44 END: OK
+2018-06-28 21:34:43.586 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 54 START
+2018-06-28 21:34:43.658 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 46 END: OK
+2018-06-28 21:34:43.663 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 55 START
+2018-06-28 21:34:43.763 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 45 END: OK
+2018-06-28 21:34:43.769 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 56 START
+2018-06-28 21:34:43.839 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 48 END: OK
+2018-06-28 21:34:43.844 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 57 START
+2018-06-28 21:34:43.854 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 49 END: OK
+2018-06-28 21:34:43.860 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 58 START
+2018-06-28 21:34:44.060 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 47 END: OK
+2018-06-28 21:34:44.066 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 59 START
+2018-06-28 21:34:44.268 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 50 END: OK
+2018-06-28 21:34:44.275 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 60 START
+2018-06-28 21:34:44.318 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 51 END: OK
+2018-06-28 21:34:44.323 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 61 START
+2018-06-28 21:34:44.503 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 53 END: OK
+2018-06-28 21:34:44.508 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 62 START
+2018-06-28 21:34:44.573 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 52 END: OK
+2018-06-28 21:34:44.578 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 63 START
+2018-06-28 21:34:44.609 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 54 END: OK
+2018-06-28 21:34:44.614 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 64 START
+2018-06-28 21:34:44.694 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 55 END: OK
+2018-06-28 21:34:44.699 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 65 START
+2018-06-28 21:34:44.724 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 56 END: OK
+2018-06-28 21:34:44.730 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 66 START
+2018-06-28 21:34:44.871 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 58 END: OK
+2018-06-28 21:34:44.876 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 67 START
+2018-06-28 21:34:45.049 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 57 END: OK
+2018-06-28 21:34:45.054 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 68 START
+2018-06-28 21:34:45.056 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 59 END: OK
+2018-06-28 21:34:45.060 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 69 START
+2018-06-28 21:34:45.341 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 60 END: OK
+2018-06-28 21:34:45.347 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 70 START
+2018-06-28 21:34:45.477 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 61 END: OK
+2018-06-28 21:34:45.482 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 71 START
+2018-06-28 21:34:45.833 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 62 END: OK
+2018-06-28 21:34:45.834 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 65 END: OK
+2018-06-28 21:34:45.838 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 72 START
+2018-06-28 21:34:45.839 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 73 START
+2018-06-28 21:34:45.869 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 63 END: OK
+2018-06-28 21:34:45.874 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 74 START
+2018-06-28 21:34:45.898 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 64 END: OK
+2018-06-28 21:34:45.901 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 75 START
+2018-06-28 21:34:45.930 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 66 END: OK
+2018-06-28 21:34:45.935 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 76 START
+2018-06-28 21:34:46.109 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 68 END: OK
+2018-06-28 21:34:46.114 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 77 START
+2018-06-28 21:34:46.140 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 67 END: OK
+2018-06-28 21:34:46.145 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 78 START
+2018-06-28 21:34:46.238 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 69 END: OK
+2018-06-28 21:34:46.244 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 79 START
+2018-06-28 21:34:46.440 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 70 END: OK
+2018-06-28 21:34:46.446 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 80 START
+2018-06-28 21:34:46.523 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 71 END: OK
+2018-06-28 21:34:46.529 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 81 START
+2018-06-28 21:34:46.822 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 73 END: OK
+2018-06-28 21:34:46.827 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 82 START
+2018-06-28 21:34:46.827 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 72 END: OK
+2018-06-28 21:34:46.832 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 83 START
+2018-06-28 21:34:47.105 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 76 END: OK
+2018-06-28 21:34:47.111 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 84 START
+2018-06-28 21:34:47.130 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 75 END: OK
+2018-06-28 21:34:47.135 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 85 START
+2018-06-28 21:34:47.436 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 78 END: OK
+2018-06-28 21:34:47.442 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 86 START
+2018-06-28 21:34:47.537 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 79 END: OK
+2018-06-28 21:34:47.542 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 87 START
+2018-06-28 21:34:47.543 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 80 END: OK
+2018-06-28 21:34:47.548 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 88 START
+2018-06-28 21:34:47.557 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 77 END: OK
+2018-06-28 21:34:47.562 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 89 START
+2018-06-28 21:34:47.580 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 74 END: OK
+2018-06-28 21:34:47.584 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 90 START
+2018-06-28 21:34:47.790 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 83 END: OK
+2018-06-28 21:34:47.795 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 91 START
+2018-06-28 21:34:47.834 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 81 END: OK
+2018-06-28 21:34:47.840 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 92 START
+2018-06-28 21:34:47.925 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 82 END: OK
+2018-06-28 21:34:47.931 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 93 START
+2018-06-28 21:34:48.095 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 85 END: OK
+2018-06-28 21:34:48.101 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 94 START
+2018-06-28 21:34:48.507 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 87 END: OK
+2018-06-28 21:34:48.511 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 95 START
+2018-06-28 21:34:48.534 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 84 END: OK
+2018-06-28 21:34:48.539 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 96 START
+2018-06-28 21:34:48.541 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 86 END: OK
+2018-06-28 21:34:48.545 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 97 START
+2018-06-28 21:34:48.557 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 89 END: OK
+2018-06-28 21:34:48.561 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 98 START
+2018-06-28 21:34:48.759 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 88 END: OK
+2018-06-28 21:34:48.765 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 99 START
+2018-06-28 21:34:48.804 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 90 END: OK
+2018-06-28 21:34:48.810 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 100 START
+2018-06-28 21:34:49.086 19203 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 93 END: OK
+2018-06-28 21:34:49.120 19191 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 91 END: OK
+2018-06-28 21:34:49.169 19190 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 92 END: OK
+2018-06-28 21:34:49.242 19199 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 94 END: OK
+2018-06-28 21:34:49.484 19189 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 96 END: OK
+2018-06-28 21:34:49.519 19196 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 95 END: OK
+2018-06-28 21:34:49.688 19211 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 98 END: OK
+2018-06-28 21:34:49.765 19188 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 97 END: OK
+2018-06-28 21:34:49.797 19206 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 99 END: OK
+2018-06-28 21:34:50.258 19192 INFO rally.task.runner [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | ITER: 100 END: OK
+2018-06-28 21:34:50.288 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context cleanup@openstack cleanup() started
+2018-06-28 21:35:19.924 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context cleanup@openstack cleanup() finished in 29.64 sec
+2018-06-28 21:35:19.924 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context roles@openstack cleanup() started
+2018-06-28 21:35:21.114 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context roles@openstack cleanup() finished in 1.19 sec
+2018-06-28 21:35:21.119 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context quotas@openstack cleanup() started
+2018-06-28 21:35:21.208 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context quotas@openstack cleanup() finished in 89.26 msec
+2018-06-28 21:35:21.209 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context users@openstack cleanup() started
+2018-06-28 21:35:26.170 18149 INFO rally.task.context [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Context users@openstack cleanup() finished in 4.96 sec
+2018-06-28 21:35:27.623 18149 INFO rally.task.engine [-] Load duration is: 12.406376
+2018-06-28 21:35:27.624 18149 INFO rally.task.engine [-] Full runner duration is: 12.45739
+2018-06-28 21:35:27.624 18149 INFO rally.task.engine [-] Full duration is: 61.156838
+2018-06-28 21:35:27.824 18149 INFO rally.task.engine [-] Task 3b7a8976-b2ca-41b4-988a-62963a22c503 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 3b7a8976-b2ca-41b4-988a-62963a22c503: finished
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_list_networks
+args position 0
+args values:
+{
+  "runner": {
+    "times": 100, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1
+      }
+    }
+  }, 
+  "args": {
+    "network_create_args": {}
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 3b7a8976-b2ca-41b4-988a-62963a22c503 has 0 error(s)
+--------------------------------------------------------------------------------
+
++---------------------------------------------------------------------------------------------------------------------------+
+|                                                   Response Times (sec)                                                    |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                 | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_network | 0.662     | 0.767        | 1.187        | 1.455        | 1.558     | 0.856     | 100.0%  | 100   |
+| neutron.list_networks  | 0.161     | 0.462        | 0.717        | 0.744        | 0.872     | 0.471     | 100.0%  | 100   |
+| total                  | 0.862     | 1.26         | 1.631        | 2.098        | 2.306     | 1.327     | 100.0%  | 100   |
+|  -> duration           | 0.862     | 1.26         | 1.631        | 2.098        | 2.306     | 1.327     | 100.0%  | 100   |
+|  -> idle_duration      | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 100   |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 14.347586
+Full duration: 52.886945
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_list_networks
+args position 0
+args values:
+{
+  "runner": {
+    "times": 100, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1
+      }
+    }, 
+    "roles": [
+      "admin"
+    ]
+  }, 
+  "args": {
+    "network_create_args": {
+      "provider:network_type": "vxlan"
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 3b7a8976-b2ca-41b4-988a-62963a22c503 has 0 error(s)
+--------------------------------------------------------------------------------
+
++---------------------------------------------------------------------------------------------------------------------------+
+|                                                   Response Times (sec)                                                    |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                 | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_network | 0.685     | 0.8          | 1.103        | 1.381        | 1.465     | 0.877     | 100.0%  | 100   |
+| neutron.list_networks  | 0.141     | 0.253        | 0.426        | 0.481        | 0.613     | 0.282     | 100.0%  | 100   |
+| total                  | 0.875     | 1.117        | 1.407        | 1.575        | 1.705     | 1.16      | 100.0%  | 100   |
+|  -> duration           | 0.875     | 1.117        | 1.407        | 1.575        | 1.705     | 1.16      | 100.0%  | 100   |
+|  -> idle_duration      | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 100   |
++------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 12.406376
+Full duration: 61.156838
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 3b7a8976-b2ca-41b4-988a-62963a22c503 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 3b7a8976-b2ca-41b4-988a-62963a22c503 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 3b7a8976-b2ca-41b4-988a-62963a22c503 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+   "NovaServers.boot_and_migrate_server": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "image": {
+                    "name": "Ubuntu 16.04"
+                }
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 1,
+                    "users_per_tenant": 1
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  f452839f-7c2f-40b9-b120-cf522ae0261d: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: f452839f-7c2f-40b9-b120-cf522ae0261d
+2018-06-28 21:35:29.798 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Starting:  Task validation.
+2018-06-28 21:35:29.806 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Starting:  Task validation of syntax.
+2018-06-28 21:35:29.818 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Completed: Task validation of syntax.
+2018-06-28 21:35:29.818 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Starting:  Task validation of required platforms.
+2018-06-28 21:35:29.824 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Completed: Task validation of required platforms.
+2018-06-28 21:35:29.824 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Starting:  Task validation of semantic.
+2018-06-28 21:35:32.541 19749 INFO rally.task.context [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Context users@openstack setup()  finished in 2.11 sec
+2018-06-28 21:35:33.813 19749 INFO rally.task.context [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Context users@openstack cleanup() started
+2018-06-28 21:35:37.082 19749 INFO rally.task.context [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Context users@openstack cleanup() finished in 3.27 sec
+2018-06-28 21:35:37.082 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Completed: Task validation of semantic.
+2018-06-28 21:35:37.083 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Completed: Task validation.
+2018-06-28 21:35:37.083 19749 INFO rally.api [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d input file is valid.
+2018-06-28 21:35:37.083 19749 INFO rally.api [-] Run Task f452839f-7c2f-40b9-b120-cf522ae0261d against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:35:37.084 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Starting:  Running task.
+2018-06-28 21:35:37.135 19749 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=cdb1baef-3d2d-444a-be05-c15d1bf98e7c)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_and_migrate_server", 
+         "description": "Migrate a server.", 
+         "scenario": {
+            "NovaServers.boot_and_migrate_server": {
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "image": {
+                  "name": "Ubuntu 16.04"
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 1, 
+               "users_per_tenant": 1
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:35:39.435 19749 INFO rally.task.context [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Context users@openstack setup()  finished in 2.27 sec
+2018-06-28 21:35:39.435 19749 INFO rally.task.context [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Context cleanup@openstack setup()  finished in 0.00 msec
+2018-06-28 21:35:40.258 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 1 START
+2018-06-28 21:35:40.260 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 2 START
+2018-06-28 21:36:13.782 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 2 END: Error GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_MtyGG4hd> has ERROR status.
+ Fault: {u'message': u'list index out of range', u'code': 500, u'created': u'2018-06-28T21:36:12Z'}
+2018-06-28 21:36:13.788 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 3 START
+2018-06-28 21:36:13.822 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 1 END: Error GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_Y8AXiDvO> has ERROR status.
+ Fault: {u'message': u"Conflict updating instance 932c5b09-8aa5-4426-962b-f8614de4ca53. Expected: {'task_state': [u'resize_prep']}. Actual: {'task_state': None}", u'code': 500, u'created': u'2018-06-28T21:36:13Z'}
+2018-06-28 21:36:13.828 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 4 START
+2018-06-28 21:37:45.088 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 4 END: OK
+2018-06-28 21:37:45.092 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 5 START
+2018-06-28 21:37:45.152 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 3 END: OK
+2018-06-28 21:37:45.157 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 6 START
+2018-06-28 21:38:16.750 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 5 END: Error GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_k1ibbx5U> has ERROR status.
+ Fault: {u'message': u'list index out of range', u'code': 500, u'created': u'2018-06-28T21:38:15Z'}
+2018-06-28 21:38:16.753 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 7 START
+2018-06-28 21:38:16.820 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 6 END: Error GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_mf7oMUZ7> has ERROR status.
+ Fault: {u'message': u'list index out of range', u'code': 500, u'created': u'2018-06-28T21:38:15Z'}
+2018-06-28 21:38:16.824 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 8 START
+2018-06-28 21:38:48.349 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 8 END: Error GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_snukelu6> has ERROR status.
+ Fault: {u'message': u"Conflict updating instance 840f41fc-83ca-47bf-91a6-d8655609ae46. Expected: {'task_state': [u'resize_prep']}. Actual: {'task_state': None}", u'code': 500, u'created': u'2018-06-28T21:38:48Z'}
+2018-06-28 21:38:48.353 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 9 START
+2018-06-28 21:39:38.186 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 7 END: OK
+2018-06-28 21:39:38.191 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 10 START
+2018-06-28 21:39:51.419 19938 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 9 END: OK
+2018-06-28 21:40:03.531 19937 INFO rally.task.runner [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | ITER: 10 END: Error GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_cfj8kOt3> has ERROR status.
+ Fault: {u'message': u"Conflict updating instance 21d21423-0b85-4665-874b-5efca614deeb. Expected: {'task_state': [u'resize_prep']}. Actual: {'task_state': None}", u'code': 500, u'created': u'2018-06-28T21:40:03Z'}
+2018-06-28 21:40:03.552 19749 INFO rally.task.context [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Context cleanup@openstack cleanup() started
+2018-06-28 21:40:11.592 19749 INFO rally.task.context [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Context cleanup@openstack cleanup() finished in 8.04 sec
+2018-06-28 21:40:11.593 19749 INFO rally.task.context [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Context users@openstack cleanup() started
+2018-06-28 21:40:14.512 19749 INFO rally.task.context [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Context users@openstack cleanup() finished in 2.92 sec
+2018-06-28 21:40:14.655 19749 INFO rally.task.engine [-] Load duration is: 262.270038
+2018-06-28 21:40:14.655 19749 INFO rally.task.engine [-] Full runner duration is: 263.313532
+2018-06-28 21:40:14.656 19749 INFO rally.task.engine [-] Full duration is: 277.369582
+2018-06-28 21:40:14.735 19749 INFO rally.task.engine [-] Task f452839f-7c2f-40b9-b120-cf522ae0261d | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task f452839f-7c2f-40b9-b120-cf522ae0261d: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_and_migrate_server
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 1, 
+      "users_per_tenant": 1
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "image": {
+      "name": "Ubuntu 16.04"
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task f452839f-7c2f-40b9-b120-cf522ae0261d has 6 error(s)
+--------------------------------------------------------------------------------
+
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_Y8AXiDvO> has ERROR status.
+ Fault: {u'message': u"Conflict updating instance 932c5b09-8aa5-4426-962b-f8614de4ca53. Expected: {'task_state': [u'resize_prep']}. Actual: {'task_state': None}", u'code': 500, u'created': u'2018-06-28T21:36:13Z'}
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 863, in run
+    self._migrate(server)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 786, in _migrate
+    CONF.openstack.nova_server_migrate_poll_interval)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 90, in _get_from_manager
+    fault=getattr(res, "fault", "n/a"))
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_Y8AXiDvO> has ERROR status.
+ Fault: {u'message': u"Conflict updating instance 932c5b09-8aa5-4426-962b-f8614de4ca53. Expected: {'task_state': [u'resize_prep']}. Actual: {'task_state': None}", u'code': 500, u'created': u'2018-06-28T21:36:13Z'}
+
+--------------------------------------------------------------------------------
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_MtyGG4hd> has ERROR status.
+ Fault: {u'message': u'list index out of range', u'code': 500, u'created': u'2018-06-28T21:36:12Z'}
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 863, in run
+    self._migrate(server)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 786, in _migrate
+    CONF.openstack.nova_server_migrate_poll_interval)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 90, in _get_from_manager
+    fault=getattr(res, "fault", "n/a"))
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_MtyGG4hd> has ERROR status.
+ Fault: {u'message': u'list index out of range', u'code': 500, u'created': u'2018-06-28T21:36:12Z'}
+
+--------------------------------------------------------------------------------
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_k1ibbx5U> has ERROR status.
+ Fault: {u'message': u'list index out of range', u'code': 500, u'created': u'2018-06-28T21:38:15Z'}
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 863, in run
+    self._migrate(server)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 786, in _migrate
+    CONF.openstack.nova_server_migrate_poll_interval)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 90, in _get_from_manager
+    fault=getattr(res, "fault", "n/a"))
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_k1ibbx5U> has ERROR status.
+ Fault: {u'message': u'list index out of range', u'code': 500, u'created': u'2018-06-28T21:38:15Z'}
+
+--------------------------------------------------------------------------------
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_mf7oMUZ7> has ERROR status.
+ Fault: {u'message': u'list index out of range', u'code': 500, u'created': u'2018-06-28T21:38:15Z'}
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 863, in run
+    self._migrate(server)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 786, in _migrate
+    CONF.openstack.nova_server_migrate_poll_interval)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 90, in _get_from_manager
+    fault=getattr(res, "fault", "n/a"))
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_mf7oMUZ7> has ERROR status.
+ Fault: {u'message': u'list index out of range', u'code': 500, u'created': u'2018-06-28T21:38:15Z'}
+
+--------------------------------------------------------------------------------
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_snukelu6> has ERROR status.
+ Fault: {u'message': u"Conflict updating instance 840f41fc-83ca-47bf-91a6-d8655609ae46. Expected: {'task_state': [u'resize_prep']}. Actual: {'task_state': None}", u'code': 500, u'created': u'2018-06-28T21:38:48Z'}
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 863, in run
+    self._migrate(server)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 786, in _migrate
+    CONF.openstack.nova_server_migrate_poll_interval)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 90, in _get_from_manager
+    fault=getattr(res, "fault", "n/a"))
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_snukelu6> has ERROR status.
+ Fault: {u'message': u"Conflict updating instance 840f41fc-83ca-47bf-91a6-d8655609ae46. Expected: {'task_state': [u'resize_prep']}. Actual: {'task_state': None}", u'code': 500, u'created': u'2018-06-28T21:38:48Z'}
+
+--------------------------------------------------------------------------------
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_cfj8kOt3> has ERROR status.
+ Fault: {u'message': u"Conflict updating instance 21d21423-0b85-4665-874b-5efca614deeb. Expected: {'task_state': [u'resize_prep']}. Actual: {'task_state': None}", u'code': 500, u'created': u'2018-06-28T21:40:03Z'}
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/servers.py", line 863, in run
+    self._migrate(server)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/nova/utils.py", line 786, in _migrate
+    CONF.openstack.nova_server_migrate_poll_interval)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 215, in wait_for_status
+    resource = update_resource(resource)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/utils.py", line 90, in _get_from_manager
+    fault=getattr(res, "fault", "n/a"))
+GetResourceErrorStatus: Resource <Server: s_rally_cdb1baef_cfj8kOt3> has ERROR status.
+ Fault: {u'message': u"Conflict updating instance 21d21423-0b85-4665-874b-5efca614deeb. Expected: {'task_state': [u'resize_prep']}. Actual: {'task_state': None}", u'code': 500, u'created': u'2018-06-28T21:40:03Z'}
+
+--------------------------------------------------------------------------------
++------------------------------------------------------------------------------------------------------------------------+
+|                                                  Response Times (sec)                                                  |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action              | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server    | 20.8      | 27.67        | 28.865       | 28.871       | 28.877    | 26.641    | 100.0%  | 10    |
+| nova.migrate        | 4.221     | 4.736        | 57.394       | 57.778       | 58.162    | 22.675    | 40.0%   | 10    |
+| nova.resize_confirm | 2.632     | 2.784        | 2.825        | 2.833        | 2.841     | 2.76      | 100.0%  | 4     |
+| nova.delete_server  | 2.455     | 2.555        | 2.605        | 2.608        | 2.611     | 2.544     | 100.0%  | 4     |
+| total               | 25.338    | 33.538       | 91.27        | 91.316       | 91.363    | 51.438    | 40.0%   | 10    |
+|  -> duration        | 24.338    | 32.538       | 90.27        | 90.316       | 90.363    | 50.438    | 40.0%   | 10    |
+|  -> idle_duration   | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 40.0%   | 10    |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 262.270038
+Full duration: 277.369582
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report f452839f-7c2f-40b9-b120-cf522ae0261d --out output.html
+
+* To generate a JUnit report, run:
+	rally task export f452839f-7c2f-40b9-b120-cf522ae0261d --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report f452839f-7c2f-40b9-b120-cf522ae0261d --json --out output.json
+
+At least one workload did not pass SLA criteria.
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NovaServers.boot_and_delete_server": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "image": {
+                    "name": "Ubuntu 16.04"
+                },
+                "force_delete": false
+            },
+            "runner": {
+                "type": "constant",
+                "times": 200,
+                "concurrency": 10
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 5
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        },
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.medium"
+                },
+                "image": {
+                    "name": "Ubuntu 16.04"
+                },
+                "auto_assign_nic": true
+            },
+            "runner": {
+                "type": "constant",
+                "times": 200,
+                "concurrency": 10
+            },
+            "context": {
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 5
+                },
+                "network": {
+                    "start_cidr": "192.168.74.0/24",
+                    "networks_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  510f3127-60e1-484c-917d-7af7487d2305: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 510f3127-60e1-484c-917d-7af7487d2305
+2018-06-28 21:40:16.747 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Starting:  Task validation.
+2018-06-28 21:40:16.758 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Starting:  Task validation of syntax.
+2018-06-28 21:40:16.790 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Completed: Task validation of syntax.
+2018-06-28 21:40:16.790 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Starting:  Task validation of required platforms.
+2018-06-28 21:40:16.803 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Completed: Task validation of required platforms.
+2018-06-28 21:40:16.804 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Starting:  Task validation of semantic.
+2018-06-28 21:40:20.046 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context users@openstack setup()  finished in 2.56 sec
+2018-06-28 21:40:22.667 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context users@openstack cleanup() started
+2018-06-28 21:40:25.999 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context users@openstack cleanup() finished in 3.33 sec
+2018-06-28 21:40:25.999 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Completed: Task validation of semantic.
+2018-06-28 21:40:25.999 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Completed: Task validation.
+2018-06-28 21:40:26.000 20358 INFO rally.api [-] Task 510f3127-60e1-484c-917d-7af7487d2305 input file is valid.
+2018-06-28 21:40:26.000 20358 INFO rally.api [-] Run Task 510f3127-60e1-484c-917d-7af7487d2305 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 21:40:26.000 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Starting:  Running task.
+2018-06-28 21:40:26.048 20358 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=79169271-552a-4bdf-a82a-52a839d39448)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_and_delete_server", 
+         "description": "Boot and delete a server.", 
+         "scenario": {
+            "NovaServers.boot_and_delete_server": {
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "image": {
+                  "name": "Ubuntu 16.04"
+               }, 
+               "force_delete": false
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 5
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 200, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 21:40:29.199 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context users@openstack setup()  finished in 3.12 sec
+2018-06-28 21:40:29.199 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context cleanup@openstack setup()  finished in 0.04 msec
+2018-06-28 21:40:29.919 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 1 START
+2018-06-28 21:40:29.922 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 2 START
+2018-06-28 21:40:29.927 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 4 START
+2018-06-28 21:40:29.927 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 3 START
+2018-06-28 21:40:29.931 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 5 START
+2018-06-28 21:40:29.933 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 6 START
+2018-06-28 21:40:29.939 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 7 START
+2018-06-28 21:40:29.942 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 8 START
+2018-06-28 21:40:29.943 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 9 START
+2018-06-28 21:40:29.943 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 10 START
+2018-06-28 21:41:40.965 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 9 END: OK
+2018-06-28 21:41:40.974 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 11 START
+2018-06-28 21:41:48.809 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 2 END: OK
+2018-06-28 21:41:48.816 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 12 START
+2018-06-28 21:41:57.075 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 8 END: OK
+2018-06-28 21:41:57.084 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 13 START
+2018-06-28 21:41:57.313 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 5 END: OK
+2018-06-28 21:41:57.320 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 14 START
+2018-06-28 21:41:57.430 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 10 END: OK
+2018-06-28 21:41:57.439 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 15 START
+2018-06-28 21:42:09.302 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 4 END: OK
+2018-06-28 21:42:09.311 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 16 START
+2018-06-28 21:42:12.528 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 6 END: OK
+2018-06-28 21:42:12.536 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 17 START
+2018-06-28 21:42:12.878 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 1 END: OK
+2018-06-28 21:42:12.886 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 3 END: OK
+2018-06-28 21:42:12.887 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 18 START
+2018-06-28 21:42:12.892 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 19 START
+2018-06-28 21:42:12.930 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 11 END: OK
+2018-06-28 21:42:12.935 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 20 START
+2018-06-28 21:42:13.051 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 7 END: OK
+2018-06-28 21:42:13.058 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 21 START
+2018-06-28 21:42:25.836 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 12 END: OK
+2018-06-28 21:42:25.842 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 22 START
+2018-06-28 21:42:54.644 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 15 END: OK
+2018-06-28 21:42:54.651 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 23 START
+2018-06-28 21:43:03.395 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 13 END: OK
+2018-06-28 21:43:03.402 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 24 START
+2018-06-28 21:43:03.624 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 14 END: OK
+2018-06-28 21:43:03.631 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 25 START
+2018-06-28 21:43:17.623 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 16 END: OK
+2018-06-28 21:43:17.631 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 26 START
+2018-06-28 21:43:23.043 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 17 END: OK
+2018-06-28 21:43:23.050 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 27 START
+2018-06-28 21:43:23.557 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 21 END: OK
+2018-06-28 21:43:23.563 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 28 START
+2018-06-28 21:43:25.326 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 22 END: OK
+2018-06-28 21:43:25.335 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 29 START
+2018-06-28 21:43:28.183 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 18 END: OK
+2018-06-28 21:43:28.189 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 30 START
+2018-06-28 21:43:28.380 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 19 END: OK
+2018-06-28 21:43:28.388 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 31 START
+2018-06-28 21:43:28.543 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 20 END: OK
+2018-06-28 21:43:28.550 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 32 START
+2018-06-28 21:43:42.453 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 23 END: OK
+2018-06-28 21:43:42.461 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 33 START
+2018-06-28 21:43:53.625 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 24 END: OK
+2018-06-28 21:43:53.632 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 34 START
+2018-06-28 21:43:56.165 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 25 END: OK
+2018-06-28 21:43:56.173 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 35 START
+2018-06-28 21:44:10.512 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 26 END: OK
+2018-06-28 21:44:10.520 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 36 START
+2018-06-28 21:44:29.442 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 27 END: OK
+2018-06-28 21:44:29.449 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 37 START
+2018-06-28 21:44:29.500 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 28 END: OK
+2018-06-28 21:44:29.508 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 38 START
+2018-06-28 21:44:31.524 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 29 END: OK
+2018-06-28 21:44:31.531 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 39 START
+2018-06-28 21:44:40.556 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 30 END: OK
+2018-06-28 21:44:40.563 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 40 START
+2018-06-28 21:44:41.421 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 31 END: OK
+2018-06-28 21:44:41.427 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 41 START
+2018-06-28 21:44:43.675 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 32 END: OK
+2018-06-28 21:44:43.682 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 42 START
+2018-06-28 21:44:48.307 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 33 END: OK
+2018-06-28 21:44:48.314 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 43 START
+2018-06-28 21:44:57.168 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 35 END: OK
+2018-06-28 21:44:57.176 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 44 START
+2018-06-28 21:44:59.528 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 34 END: OK
+2018-06-28 21:44:59.536 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 45 START
+2018-06-28 21:45:00.797 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 36 END: OK
+2018-06-28 21:45:00.804 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 46 START
+2018-06-28 21:45:26.562 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 37 END: OK
+2018-06-28 21:45:26.569 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 47 START
+2018-06-28 21:45:28.572 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 38 END: OK
+2018-06-28 21:45:28.579 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 48 START
+2018-06-28 21:45:31.361 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 39 END: OK
+2018-06-28 21:45:31.366 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 49 START
+2018-06-28 21:45:48.958 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 40 END: OK
+2018-06-28 21:45:48.966 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 50 START
+2018-06-28 21:45:50.343 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 41 END: OK
+2018-06-28 21:45:50.350 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 51 START
+2018-06-28 21:45:51.908 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 42 END: OK
+2018-06-28 21:45:51.914 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 52 START
+2018-06-28 21:45:54.616 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 43 END: OK
+2018-06-28 21:45:54.622 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 53 START
+2018-06-28 21:45:58.448 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 44 END: OK
+2018-06-28 21:45:58.455 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 54 START
+2018-06-28 21:46:03.361 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 45 END: OK
+2018-06-28 21:46:03.368 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 55 START
+2018-06-28 21:46:05.884 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 46 END: OK
+2018-06-28 21:46:05.890 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 56 START
+2018-06-28 21:46:27.961 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 48 END: OK
+2018-06-28 21:46:27.967 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 57 START
+2018-06-28 21:46:28.061 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 47 END: OK
+2018-06-28 21:46:28.068 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 58 START
+2018-06-28 21:46:30.209 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 49 END: OK
+2018-06-28 21:46:30.215 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 59 START
+2018-06-28 21:46:52.839 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 50 END: OK
+2018-06-28 21:46:52.846 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 60 START
+2018-06-28 21:46:54.037 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 51 END: OK
+2018-06-28 21:46:54.045 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 61 START
+2018-06-28 21:46:57.903 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 52 END: OK
+2018-06-28 21:46:57.909 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 62 START
+2018-06-28 21:46:57.941 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 53 END: OK
+2018-06-28 21:46:57.946 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 63 START
+2018-06-28 21:47:00.208 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 54 END: OK
+2018-06-28 21:47:00.215 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 64 START
+2018-06-28 21:47:13.669 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 55 END: OK
+2018-06-28 21:47:13.676 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 65 START
+2018-06-28 21:47:16.081 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 56 END: OK
+2018-06-28 21:47:16.088 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 66 START
+2018-06-28 21:47:27.016 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 57 END: OK
+2018-06-28 21:47:27.022 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 67 START
+2018-06-28 21:47:31.688 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 59 END: OK
+2018-06-28 21:47:31.695 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 68 START
+2018-06-28 21:47:31.813 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 58 END: OK
+2018-06-28 21:47:31.819 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 69 START
+2018-06-28 21:47:50.353 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 60 END: OK
+2018-06-28 21:47:50.360 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 70 START
+2018-06-28 21:47:53.497 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 61 END: OK
+2018-06-28 21:47:53.505 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 71 START
+2018-06-28 21:48:00.081 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 63 END: OK
+2018-06-28 21:48:00.086 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 72 START
+2018-06-28 21:48:01.586 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 62 END: OK
+2018-06-28 21:48:01.592 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 73 START
+2018-06-28 21:48:03.994 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 64 END: OK
+2018-06-28 21:48:04.003 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 74 START
+2018-06-28 21:48:21.840 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 65 END: OK
+2018-06-28 21:48:21.846 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 75 START
+2018-06-28 21:48:23.959 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 66 END: OK
+2018-06-28 21:48:23.966 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 76 START
+2018-06-28 21:48:28.714 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 67 END: OK
+2018-06-28 21:48:28.720 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 77 START
+2018-06-28 21:48:30.881 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 68 END: OK
+2018-06-28 21:48:30.888 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 78 START
+2018-06-28 21:48:31.565 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 69 END: OK
+2018-06-28 21:48:31.572 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 79 START
+2018-06-28 21:48:52.216 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 70 END: OK
+2018-06-28 21:48:52.223 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 80 START
+2018-06-28 21:48:54.839 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 71 END: OK
+2018-06-28 21:48:54.846 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 81 START
+2018-06-28 21:49:01.529 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 72 END: OK
+2018-06-28 21:49:01.534 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 82 START
+2018-06-28 21:49:05.739 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 73 END: OK
+2018-06-28 21:49:05.746 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 83 START
+2018-06-28 21:49:07.970 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 74 END: OK
+2018-06-28 21:49:07.976 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 84 START
+2018-06-28 21:49:25.774 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 75 END: OK
+2018-06-28 21:49:25.782 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 85 START
+2018-06-28 21:49:27.747 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 76 END: OK
+2018-06-28 21:49:27.754 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 86 START
+2018-06-28 21:49:33.386 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 77 END: OK
+2018-06-28 21:49:33.392 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 87 START
+2018-06-28 21:49:36.671 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 78 END: OK
+2018-06-28 21:49:36.678 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 88 START
+2018-06-28 21:49:37.659 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 79 END: OK
+2018-06-28 21:49:37.665 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 89 START
+2018-06-28 21:49:53.758 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 80 END: OK
+2018-06-28 21:49:53.765 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 90 START
+2018-06-28 21:49:56.054 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 81 END: OK
+2018-06-28 21:49:56.060 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 91 START
+2018-06-28 21:50:01.240 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 82 END: OK
+2018-06-28 21:50:01.247 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 92 START
+2018-06-28 21:50:05.157 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 83 END: OK
+2018-06-28 21:50:05.164 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 93 START
+2018-06-28 21:50:07.345 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 84 END: OK
+2018-06-28 21:50:07.352 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 94 START
+2018-06-28 21:50:27.122 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 85 END: OK
+2018-06-28 21:50:27.128 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 95 START
+2018-06-28 21:50:31.702 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 86 END: OK
+2018-06-28 21:50:31.707 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 96 START
+2018-06-28 21:50:35.022 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 87 END: OK
+2018-06-28 21:50:35.029 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 97 START
+2018-06-28 21:50:38.419 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 88 END: OK
+2018-06-28 21:50:38.425 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 98 START
+2018-06-28 21:50:41.333 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 89 END: OK
+2018-06-28 21:50:41.340 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 99 START
+2018-06-28 21:50:59.710 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 90 END: OK
+2018-06-28 21:50:59.717 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 100 START
+2018-06-28 21:51:02.117 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 91 END: OK
+2018-06-28 21:51:02.124 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 101 START
+2018-06-28 21:51:05.116 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 92 END: OK
+2018-06-28 21:51:05.122 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 102 START
+2018-06-28 21:51:06.969 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 93 END: OK
+2018-06-28 21:51:06.975 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 103 START
+2018-06-28 21:51:09.031 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 94 END: OK
+2018-06-28 21:51:09.037 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 104 START
+2018-06-28 21:51:28.623 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 95 END: OK
+2018-06-28 21:51:28.628 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 105 START
+2018-06-28 21:51:31.242 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 96 END: OK
+2018-06-28 21:51:31.249 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 106 START
+2018-06-28 21:51:38.799 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 97 END: OK
+2018-06-28 21:51:38.805 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 107 START
+2018-06-28 21:51:39.835 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 98 END: OK
+2018-06-28 21:51:39.841 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 108 START
+2018-06-28 21:51:40.572 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 99 END: OK
+2018-06-28 21:51:40.578 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 109 START
+2018-06-28 21:52:03.659 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 100 END: OK
+2018-06-28 21:52:03.666 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 110 START
+2018-06-28 21:52:08.083 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 101 END: OK
+2018-06-28 21:52:08.091 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 111 START
+2018-06-28 21:52:08.764 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 102 END: OK
+2018-06-28 21:52:08.768 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 112 START
+2018-06-28 21:52:10.884 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 103 END: OK
+2018-06-28 21:52:10.890 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 113 START
+2018-06-28 21:52:13.233 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 104 END: OK
+2018-06-28 21:52:13.240 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 114 START
+2018-06-28 21:52:33.002 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 105 END: OK
+2018-06-28 21:52:33.009 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 115 START
+2018-06-28 21:52:33.063 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 106 END: OK
+2018-06-28 21:52:33.069 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 116 START
+2018-06-28 21:52:46.196 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 108 END: OK
+2018-06-28 21:52:46.202 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 117 START
+2018-06-28 21:52:46.438 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 109 END: OK
+2018-06-28 21:52:46.444 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 118 START
+2018-06-28 21:52:46.931 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 107 END: OK
+2018-06-28 21:52:46.938 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 119 START
+2018-06-28 21:53:02.728 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 110 END: OK
+2018-06-28 21:53:02.735 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 120 START
+2018-06-28 21:53:05.684 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 111 END: OK
+2018-06-28 21:53:05.691 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 121 START
+2018-06-28 21:53:07.652 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 113 END: OK
+2018-06-28 21:53:07.658 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 122 START
+2018-06-28 21:53:10.181 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 112 END: OK
+2018-06-28 21:53:10.187 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 123 START
+2018-06-28 21:53:12.067 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 114 END: OK
+2018-06-28 21:53:12.074 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 124 START
+2018-06-28 21:53:30.137 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 115 END: OK
+2018-06-28 21:53:30.144 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 125 START
+2018-06-28 21:53:32.325 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 116 END: OK
+2018-06-28 21:53:32.331 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 126 START
+2018-06-28 21:53:50.245 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 118 END: OK
+2018-06-28 21:53:50.250 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 127 START
+2018-06-28 21:53:50.291 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 117 END: OK
+2018-06-28 21:53:50.298 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 128 START
+2018-06-28 21:53:50.659 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 119 END: OK
+2018-06-28 21:53:50.665 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 129 START
+2018-06-28 21:54:09.075 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 120 END: OK
+2018-06-28 21:54:09.083 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 130 START
+2018-06-28 21:54:13.368 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 122 END: OK
+2018-06-28 21:54:13.375 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 131 START
+2018-06-28 21:54:13.696 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 121 END: OK
+2018-06-28 21:54:13.703 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 132 START
+2018-06-28 21:54:15.606 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 123 END: OK
+2018-06-28 21:54:15.612 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 133 START
+2018-06-28 21:54:15.908 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 124 END: OK
+2018-06-28 21:54:15.914 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 134 START
+2018-06-28 21:54:23.076 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 125 END: OK
+2018-06-28 21:54:23.081 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 135 START
+2018-06-28 21:54:31.720 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 126 END: OK
+2018-06-28 21:54:31.727 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 136 START
+2018-06-28 21:54:51.769 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 129 END: OK
+2018-06-28 21:54:51.776 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 137 START
+2018-06-28 21:54:51.833 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 127 END: OK
+2018-06-28 21:54:51.838 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 138 START
+2018-06-28 21:54:52.296 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 128 END: OK
+2018-06-28 21:54:52.302 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 139 START
+2018-06-28 21:55:10.977 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 130 END: OK
+2018-06-28 21:55:10.984 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 140 START
+2018-06-28 21:55:22.116 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 133 END: OK
+2018-06-28 21:55:22.122 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 141 START
+2018-06-28 21:55:22.140 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 131 END: OK
+2018-06-28 21:55:22.146 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 142 START
+2018-06-28 21:55:22.440 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 132 END: OK
+2018-06-28 21:55:22.448 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 143 START
+2018-06-28 21:55:24.105 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 134 END: OK
+2018-06-28 21:55:24.112 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 144 START
+2018-06-28 21:55:24.610 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 135 END: OK
+2018-06-28 21:55:24.617 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 145 START
+2018-06-28 21:55:26.461 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 136 END: OK
+2018-06-28 21:55:26.468 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 146 START
+2018-06-28 21:55:51.607 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 139 END: OK
+2018-06-28 21:55:51.614 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 147 START
+2018-06-28 21:55:53.355 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 137 END: OK
+2018-06-28 21:55:53.361 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 148 START
+2018-06-28 21:55:55.687 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 138 END: OK
+2018-06-28 21:55:55.693 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 149 START
+2018-06-28 21:56:01.023 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 140 END: OK
+2018-06-28 21:56:01.030 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 150 START
+2018-06-28 21:56:25.833 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 141 END: OK
+2018-06-28 21:56:25.839 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 151 START
+2018-06-28 21:56:28.772 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 142 END: OK
+2018-06-28 21:56:28.779 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 152 START
+2018-06-28 21:56:29.684 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 143 END: OK
+2018-06-28 21:56:29.691 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 153 START
+2018-06-28 21:56:30.604 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 144 END: OK
+2018-06-28 21:56:30.611 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 154 START
+2018-06-28 21:56:31.190 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 145 END: OK
+2018-06-28 21:56:31.197 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 155 START
+2018-06-28 21:56:33.146 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 146 END: OK
+2018-06-28 21:56:33.152 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 156 START
+2018-06-28 21:56:59.458 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 148 END: OK
+2018-06-28 21:56:59.464 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 157 START
+2018-06-28 21:57:00.477 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 147 END: OK
+2018-06-28 21:57:00.483 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 158 START
+2018-06-28 21:57:04.536 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 149 END: OK
+2018-06-28 21:57:04.541 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 159 START
+2018-06-28 21:57:04.907 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 150 END: OK
+2018-06-28 21:57:04.914 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 160 START
+2018-06-28 21:57:16.158 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 151 END: OK
+2018-06-28 21:57:16.163 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 161 START
+2018-06-28 21:57:34.582 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 152 END: OK
+2018-06-28 21:57:34.588 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 162 START
+2018-06-28 21:57:36.008 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 153 END: OK
+2018-06-28 21:57:36.014 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 163 START
+2018-06-28 21:57:36.683 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 156 END: OK
+2018-06-28 21:57:36.690 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 164 START
+2018-06-28 21:57:36.912 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 154 END: OK
+2018-06-28 21:57:36.918 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 165 START
+2018-06-28 21:57:37.386 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 155 END: OK
+2018-06-28 21:57:37.392 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 166 START
+2018-06-28 21:58:03.288 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 157 END: OK
+2018-06-28 21:58:03.293 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 167 START
+2018-06-28 21:58:04.235 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 158 END: OK
+2018-06-28 21:58:04.241 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 168 START
+2018-06-28 21:58:06.195 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 160 END: OK
+2018-06-28 21:58:06.201 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 169 START
+2018-06-28 21:58:08.450 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 159 END: OK
+2018-06-28 21:58:08.456 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 170 START
+2018-06-28 21:58:08.941 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 161 END: OK
+2018-06-28 21:58:08.946 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 171 START
+2018-06-28 21:58:37.890 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 162 END: OK
+2018-06-28 21:58:37.897 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 172 START
+2018-06-28 21:58:42.433 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 163 END: OK
+2018-06-28 21:58:42.439 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 173 START
+2018-06-28 21:58:43.081 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 165 END: OK
+2018-06-28 21:58:43.087 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 174 START
+2018-06-28 21:58:43.093 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 166 END: OK
+2018-06-28 21:58:43.099 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 175 START
+2018-06-28 21:58:43.123 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 164 END: OK
+2018-06-28 21:58:43.127 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 176 START
+2018-06-28 21:59:07.984 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 168 END: OK
+2018-06-28 21:59:07.989 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 177 START
+2018-06-28 21:59:11.924 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 167 END: OK
+2018-06-28 21:59:11.931 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 178 START
+2018-06-28 21:59:14.706 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 169 END: OK
+2018-06-28 21:59:14.712 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 179 START
+2018-06-28 21:59:14.770 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 170 END: OK
+2018-06-28 21:59:14.775 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 180 START
+2018-06-28 21:59:15.045 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 171 END: OK
+2018-06-28 21:59:15.052 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 181 START
+2018-06-28 21:59:18.689 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 172 END: OK
+2018-06-28 21:59:18.696 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 182 START
+2018-06-28 21:59:46.234 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 173 END: OK
+2018-06-28 21:59:46.241 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 183 START
+2018-06-28 21:59:46.497 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 176 END: OK
+2018-06-28 21:59:46.503 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 184 START
+2018-06-28 21:59:46.594 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 175 END: OK
+2018-06-28 21:59:46.600 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 185 START
+2018-06-28 21:59:47.093 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 174 END: OK
+2018-06-28 21:59:47.105 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 186 START
+2018-06-28 22:00:09.149 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 177 END: OK
+2018-06-28 22:00:09.154 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 187 START
+2018-06-28 22:00:13.402 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 178 END: OK
+2018-06-28 22:00:13.408 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 188 START
+2018-06-28 22:00:20.540 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 182 END: OK
+2018-06-28 22:00:20.544 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 189 START
+2018-06-28 22:00:20.707 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 179 END: OK
+2018-06-28 22:00:20.713 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 190 START
+2018-06-28 22:00:21.005 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 181 END: OK
+2018-06-28 22:00:21.010 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 191 START
+2018-06-28 22:00:22.391 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 180 END: OK
+2018-06-28 22:00:22.396 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 192 START
+2018-06-28 22:00:50.535 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 184 END: OK
+2018-06-28 22:00:50.543 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 193 START
+2018-06-28 22:00:50.772 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 186 END: OK
+2018-06-28 22:00:50.779 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 194 START
+2018-06-28 22:00:52.516 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 183 END: OK
+2018-06-28 22:00:52.523 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 195 START
+2018-06-28 22:00:52.861 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 185 END: OK
+2018-06-28 22:00:52.866 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 196 START
+2018-06-28 22:01:05.883 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 187 END: OK
+2018-06-28 22:01:05.888 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 197 START
+2018-06-28 22:01:15.168 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 188 END: OK
+2018-06-28 22:01:15.174 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 198 START
+2018-06-28 22:01:24.947 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 190 END: OK
+2018-06-28 22:01:24.953 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 199 START
+2018-06-28 22:01:25.945 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 192 END: OK
+2018-06-28 22:01:25.951 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 200 START
+2018-06-28 22:01:26.288 20503 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 189 END: OK
+2018-06-28 22:01:27.540 20507 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 191 END: OK
+2018-06-28 22:01:46.976 20488 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 195 END: OK
+2018-06-28 22:01:47.480 20489 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 193 END: OK
+2018-06-28 22:01:47.788 20501 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 196 END: OK
+2018-06-28 22:01:47.924 20491 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 194 END: OK
+2018-06-28 22:01:51.925 20487 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 197 END: OK
+2018-06-28 22:01:54.620 20497 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 198 END: OK
+2018-06-28 22:02:00.960 20495 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 200 END: OK
+2018-06-28 22:02:01.629 20486 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 199 END: OK
+2018-06-28 22:02:01.657 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context cleanup@openstack cleanup() started
+2018-06-28 22:02:12.337 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context cleanup@openstack cleanup() finished in 10.68 sec
+2018-06-28 22:02:12.338 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context users@openstack cleanup() started
+2018-06-28 22:02:18.066 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context users@openstack cleanup() finished in 5.73 sec
+2018-06-28 22:02:19.083 20358 INFO rally.task.engine [-] Load duration is: 1290.707258
+2018-06-28 22:02:19.083 20358 INFO rally.task.engine [-] Full runner duration is: 1291.758288
+2018-06-28 22:02:19.083 20358 INFO rally.task.engine [-] Full duration is: 1312.010796
+2018-06-28 22:02:19.259 20358 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=89a9e355-6dca-4067-93c9-088868d17fd3)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_and_delete_server", 
+         "description": "Boot and delete a server.", 
+         "scenario": {
+            "NovaServers.boot_and_delete_server": {
+               "flavor": {
+                  "name": "m1.medium"
+               }, 
+               "image": {
+                  "name": "Ubuntu 16.04"
+               }, 
+               "auto_assign_nic": true
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 5
+            }, 
+            "network": {
+               "start_cidr": "192.168.74.0/24", 
+               "networks_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 200, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 22:02:22.397 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context users@openstack setup()  finished in 3.11 sec
+2018-06-28 22:02:49.880 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context network@openstack setup()  finished in 27.48 sec
+2018-06-28 22:02:49.880 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-28 22:02:50.958 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 2 START
+2018-06-28 22:02:50.958 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 1 START
+2018-06-28 22:02:50.961 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 3 START
+2018-06-28 22:02:50.968 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 4 START
+2018-06-28 22:02:50.968 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 5 START
+2018-06-28 22:02:50.974 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 6 START
+2018-06-28 22:02:50.975 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 7 START
+2018-06-28 22:02:50.978 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 9 START
+2018-06-28 22:02:50.980 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 8 START
+2018-06-28 22:02:50.982 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 10 START
+2018-06-28 22:04:04.484 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 6 END: OK
+2018-06-28 22:04:04.494 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 11 START
+2018-06-28 22:04:14.084 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 7 END: OK
+2018-06-28 22:04:14.093 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 12 START
+2018-06-28 22:04:16.011 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 2 END: OK
+2018-06-28 22:04:16.025 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 13 START
+2018-06-28 22:04:16.238 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 3 END: OK
+2018-06-28 22:04:16.251 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 14 START
+2018-06-28 22:04:22.440 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 5 END: OK
+2018-06-28 22:04:22.451 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 15 START
+2018-06-28 22:04:22.508 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 9 END: OK
+2018-06-28 22:04:22.516 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 16 START
+2018-06-28 22:04:22.609 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 1 END: OK
+2018-06-28 22:04:22.618 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 17 START
+2018-06-28 22:04:22.922 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 10 END: OK
+2018-06-28 22:04:22.932 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 18 START
+2018-06-28 22:04:23.217 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 4 END: OK
+2018-06-28 22:04:23.227 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 19 START
+2018-06-28 22:04:24.805 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 8 END: OK
+2018-06-28 22:04:24.814 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 20 START
+2018-06-28 22:04:48.332 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 11 END: OK
+2018-06-28 22:04:48.339 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 21 START
+2018-06-28 22:05:18.067 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 12 END: OK
+2018-06-28 22:05:18.075 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 22 START
+2018-06-28 22:05:20.601 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 13 END: OK
+2018-06-28 22:05:20.609 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 23 START
+2018-06-28 22:05:25.091 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 14 END: OK
+2018-06-28 22:05:25.098 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 24 START
+2018-06-28 22:05:39.957 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 16 END: OK
+2018-06-28 22:05:39.965 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 25 START
+2018-06-28 22:05:40.075 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 18 END: OK
+2018-06-28 22:05:40.085 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 26 START
+2018-06-28 22:05:42.336 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 15 END: OK
+2018-06-28 22:05:42.344 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 27 START
+2018-06-28 22:05:42.432 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 17 END: OK
+2018-06-28 22:05:42.440 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 28 START
+2018-06-28 22:05:42.979 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 19 END: OK
+2018-06-28 22:05:42.986 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 29 START
+2018-06-28 22:05:43.291 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 21 END: OK
+2018-06-28 22:05:43.301 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 30 START
+2018-06-28 22:05:44.765 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 20 END: OK
+2018-06-28 22:05:44.772 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 31 START
+2018-06-28 22:06:00.009 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 22 END: OK
+2018-06-28 22:06:00.017 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 32 START
+2018-06-28 22:06:08.500 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 23 END: OK
+2018-06-28 22:06:08.507 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 33 START
+2018-06-28 22:06:17.272 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 24 END: OK
+2018-06-28 22:06:17.282 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 34 START
+2018-06-28 22:06:46.118 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 25 END: OK
+2018-06-28 22:06:46.126 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 35 START
+2018-06-28 22:06:48.363 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 26 END: OK
+2018-06-28 22:06:48.372 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 36 START
+2018-06-28 22:06:55.698 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 29 END: OK
+2018-06-28 22:06:55.707 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 37 START
+2018-06-28 22:06:57.637 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 28 END: OK
+2018-06-28 22:06:57.644 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 38 START
+2018-06-28 22:06:58.055 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 27 END: OK
+2018-06-28 22:06:58.063 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 39 START
+2018-06-28 22:06:59.718 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 31 END: OK
+2018-06-28 22:06:59.726 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 40 START
+2018-06-28 22:07:00.883 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 30 END: OK
+2018-06-28 22:07:00.891 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 41 START
+2018-06-28 22:07:01.844 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 32 END: OK
+2018-06-28 22:07:01.851 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 42 START
+2018-06-28 22:07:19.860 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 34 END: OK
+2018-06-28 22:07:19.868 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 43 START
+2018-06-28 22:07:21.188 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 33 END: OK
+2018-06-28 22:07:21.196 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 44 START
+2018-06-28 22:07:31.756 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 35 END: OK
+2018-06-28 22:07:31.763 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 45 START
+2018-06-28 22:07:45.187 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 36 END: OK
+2018-06-28 22:07:45.195 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 46 START
+2018-06-28 22:08:04.092 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 37 END: OK
+2018-06-28 22:08:04.104 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 47 START
+2018-06-28 22:08:05.798 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 38 END: OK
+2018-06-28 22:08:05.805 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 48 START
+2018-06-28 22:08:06.064 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 40 END: OK
+2018-06-28 22:08:06.071 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 49 START
+2018-06-28 22:08:06.676 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 41 END: OK
+2018-06-28 22:08:06.683 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 50 START
+2018-06-28 22:08:06.795 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 39 END: OK
+2018-06-28 22:08:06.802 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 51 START
+2018-06-28 22:08:10.482 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 42 END: OK
+2018-06-28 22:08:10.489 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 52 START
+2018-06-28 22:08:31.533 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 44 END: OK
+2018-06-28 22:08:31.542 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 53 START
+2018-06-28 22:08:32.786 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 43 END: OK
+2018-06-28 22:08:32.792 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 54 START
+2018-06-28 22:08:33.107 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 45 END: OK
+2018-06-28 22:08:33.115 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 55 START
+2018-06-28 22:08:39.877 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 46 END: OK
+2018-06-28 22:08:39.883 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 56 START
+2018-06-28 22:09:00.972 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 47 END: OK
+2018-06-28 22:09:00.980 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 57 START
+2018-06-28 22:09:14.048 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 49 END: OK
+2018-06-28 22:09:14.055 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 58 START
+2018-06-28 22:09:14.400 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 50 END: OK
+2018-06-28 22:09:14.407 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 59 START
+2018-06-28 22:09:14.887 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 48 END: OK
+2018-06-28 22:09:14.895 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 60 START
+2018-06-28 22:09:15.008 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 51 END: OK
+2018-06-28 22:09:15.016 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 61 START
+2018-06-28 22:09:16.483 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 52 END: OK
+2018-06-28 22:09:16.490 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 62 START
+2018-06-28 22:09:39.216 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 55 END: OK
+2018-06-28 22:09:39.222 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 63 START
+2018-06-28 22:09:39.796 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 53 END: OK
+2018-06-28 22:09:39.803 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 64 START
+2018-06-28 22:09:43.381 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 54 END: OK
+2018-06-28 22:09:43.387 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 65 START
+2018-06-28 22:09:43.508 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 56 END: OK
+2018-06-28 22:09:43.514 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 66 START
+2018-06-28 22:09:46.211 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 57 END: OK
+2018-06-28 22:09:46.217 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 67 START
+2018-06-28 22:10:13.249 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 58 END: OK
+2018-06-28 22:10:13.255 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 68 START
+2018-06-28 22:10:20.569 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 59 END: OK
+2018-06-28 22:10:20.576 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 69 START
+2018-06-28 22:10:20.964 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 60 END: OK
+2018-06-28 22:10:20.974 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 70 START
+2018-06-28 22:10:21.058 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 61 END: OK
+2018-06-28 22:10:21.065 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 71 START
+2018-06-28 22:10:22.204 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 62 END: OK
+2018-06-28 22:10:22.214 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 72 START
+2018-06-28 22:10:48.439 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 64 END: OK
+2018-06-28 22:10:48.447 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 73 START
+2018-06-28 22:10:51.936 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 63 END: OK
+2018-06-28 22:10:51.943 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 74 START
+2018-06-28 22:10:52.156 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 66 END: OK
+2018-06-28 22:10:52.162 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 75 START
+2018-06-28 22:10:52.306 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 65 END: OK
+2018-06-28 22:10:52.312 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 76 START
+2018-06-28 22:10:52.598 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 67 END: OK
+2018-06-28 22:10:52.605 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 77 START
+2018-06-28 22:10:54.109 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 68 END: OK
+2018-06-28 22:10:54.116 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 78 START
+2018-06-28 22:11:19.912 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 69 END: OK
+2018-06-28 22:11:19.919 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 79 START
+2018-06-28 22:11:21.583 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 72 END: OK
+2018-06-28 22:11:21.589 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 80 START
+2018-06-28 22:11:24.996 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 70 END: OK
+2018-06-28 22:11:25.004 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 81 START
+2018-06-28 22:11:25.163 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 71 END: OK
+2018-06-28 22:11:25.169 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 82 START
+2018-06-28 22:11:43.502 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 73 END: OK
+2018-06-28 22:11:43.509 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 83 START
+2018-06-28 22:11:58.055 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 74 END: OK
+2018-06-28 22:11:58.061 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 84 START
+2018-06-28 22:11:58.156 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 75 END: OK
+2018-06-28 22:11:58.161 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 85 START
+2018-06-28 22:11:58.593 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 77 END: OK
+2018-06-28 22:11:58.599 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 86 START
+2018-06-28 22:12:00.173 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 78 END: OK
+2018-06-28 22:12:00.180 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 87 START
+2018-06-28 22:12:00.450 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 76 END: OK
+2018-06-28 22:12:00.455 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 88 START
+2018-06-28 22:12:25.888 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 79 END: OK
+2018-06-28 22:12:25.895 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 89 START
+2018-06-28 22:12:28.191 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 80 END: OK
+2018-06-28 22:12:28.199 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 90 START
+2018-06-28 22:12:28.923 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 82 END: OK
+2018-06-28 22:12:28.930 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 91 START
+2018-06-28 22:12:29.267 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 81 END: OK
+2018-06-28 22:12:29.274 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 92 START
+2018-06-28 22:12:34.302 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 83 END: OK
+2018-06-28 22:12:34.309 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 93 START
+2018-06-28 22:12:59.703 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 85 END: OK
+2018-06-28 22:12:59.710 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 94 START
+2018-06-28 22:13:04.688 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 86 END: OK
+2018-06-28 22:13:04.694 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 95 START
+2018-06-28 22:13:06.395 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 84 END: OK
+2018-06-28 22:13:06.402 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 96 START
+2018-06-28 22:13:06.498 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 87 END: OK
+2018-06-28 22:13:06.504 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 97 START
+2018-06-28 22:13:08.483 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 88 END: OK
+2018-06-28 22:13:08.490 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 98 START
+2018-06-28 22:13:35.149 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 92 END: OK
+2018-06-28 22:13:35.155 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 99 START
+2018-06-28 22:13:35.696 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 93 END: OK
+2018-06-28 22:13:35.701 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 100 START
+2018-06-28 22:13:36.936 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 89 END: OK
+2018-06-28 22:13:36.942 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 101 START
+2018-06-28 22:13:37.557 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 91 END: OK
+2018-06-28 22:13:37.564 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 102 START
+2018-06-28 22:13:38.385 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 90 END: OK
+2018-06-28 22:13:38.390 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 103 START
+2018-06-28 22:13:52.271 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 94 END: OK
+2018-06-28 22:13:52.277 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 104 START
+2018-06-28 22:14:10.062 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 98 END: OK
+2018-06-28 22:14:10.068 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 105 START
+2018-06-28 22:14:12.455 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 97 END: OK
+2018-06-28 22:14:12.462 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 106 START
+2018-06-28 22:14:13.356 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 95 END: OK
+2018-06-28 22:14:13.363 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 107 START
+2018-06-28 22:14:14.416 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 96 END: OK
+2018-06-28 22:14:14.422 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 108 START
+2018-06-28 22:14:32.188 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 99 END: OK
+2018-06-28 22:14:32.195 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 109 START
+2018-06-28 22:14:38.074 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 100 END: OK
+2018-06-28 22:14:38.081 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 110 START
+2018-06-28 22:14:40.643 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 101 END: OK
+2018-06-28 22:14:40.649 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 111 START
+2018-06-28 22:14:41.858 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 102 END: OK
+2018-06-28 22:14:41.866 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 112 START
+2018-06-28 22:14:42.292 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 103 END: OK
+2018-06-28 22:14:42.299 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 113 START
+2018-06-28 22:14:49.166 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 104 END: OK
+2018-06-28 22:14:49.171 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 114 START
+2018-06-28 22:15:11.644 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 105 END: OK
+2018-06-28 22:15:11.650 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 115 START
+2018-06-28 22:15:16.811 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 107 END: OK
+2018-06-28 22:15:16.817 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 116 START
+2018-06-28 22:15:20.303 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 108 END: OK
+2018-06-28 22:15:20.310 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 117 START
+2018-06-28 22:15:20.629 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 106 END: OK
+2018-06-28 22:15:20.635 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 118 START
+2018-06-28 22:15:33.712 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 109 END: OK
+2018-06-28 22:15:33.718 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 119 START
+2018-06-28 22:15:39.538 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 110 END: OK
+2018-06-28 22:15:39.545 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 120 START
+2018-06-28 22:15:49.009 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 111 END: OK
+2018-06-28 22:15:49.016 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 121 START
+2018-06-28 22:15:52.473 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 112 END: OK
+2018-06-28 22:15:52.479 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 122 START
+2018-06-28 22:15:52.811 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 113 END: OK
+2018-06-28 22:15:52.816 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 123 START
+2018-06-28 22:15:52.977 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 114 END: OK
+2018-06-28 22:15:52.983 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 124 START
+2018-06-28 22:16:08.838 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 115 END: OK
+2018-06-28 22:16:08.844 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 125 START
+2018-06-28 22:16:15.874 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 116 END: OK
+2018-06-28 22:16:15.880 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 126 START
+2018-06-28 22:16:21.546 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 117 END: OK
+2018-06-28 22:16:21.552 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 127 START
+2018-06-28 22:16:22.488 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 118 END: OK
+2018-06-28 22:16:22.494 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 128 START
+2018-06-28 22:16:33.046 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 119 END: OK
+2018-06-28 22:16:33.052 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 129 START
+2018-06-28 22:16:38.710 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 120 END: OK
+2018-06-28 22:16:38.716 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 130 START
+2018-06-28 22:16:53.215 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 121 END: OK
+2018-06-28 22:16:53.221 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 131 START
+2018-06-28 22:16:58.934 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 124 END: OK
+2018-06-28 22:16:58.940 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 132 START
+2018-06-28 22:17:00.381 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 122 END: OK
+2018-06-28 22:17:00.387 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 133 START
+2018-06-28 22:17:00.983 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 123 END: OK
+2018-06-28 22:17:00.990 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 134 START
+2018-06-28 22:17:10.815 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 125 END: OK
+2018-06-28 22:17:10.821 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 135 START
+2018-06-28 22:17:19.522 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 126 END: OK
+2018-06-28 22:17:19.528 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 136 START
+2018-06-28 22:17:27.679 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 127 END: OK
+2018-06-28 22:17:27.685 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 137 START
+2018-06-28 22:17:28.102 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 128 END: OK
+2018-06-28 22:17:28.108 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 138 START
+2018-06-28 22:17:32.491 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 129 END: OK
+2018-06-28 22:17:32.498 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 139 START
+2018-06-28 22:17:38.941 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 130 END: OK
+2018-06-28 22:17:38.948 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 140 START
+2018-06-28 22:17:56.814 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 131 END: OK
+2018-06-28 22:17:56.822 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 141 START
+2018-06-28 22:18:02.943 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 132 END: OK
+2018-06-28 22:18:02.948 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 142 START
+2018-06-28 22:18:05.167 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 134 END: OK
+2018-06-28 22:18:05.173 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 143 START
+2018-06-28 22:18:06.933 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 133 END: OK
+2018-06-28 22:18:06.940 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 144 START
+2018-06-28 22:18:10.525 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 135 END: OK
+2018-06-28 22:18:10.531 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 145 START
+2018-06-28 22:18:25.259 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 136 END: OK
+2018-06-28 22:18:25.265 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 146 START
+2018-06-28 22:18:31.776 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 138 END: OK
+2018-06-28 22:18:31.783 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 147 START
+2018-06-28 22:18:33.737 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 137 END: OK
+2018-06-28 22:18:33.744 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 148 START
+2018-06-28 22:18:33.909 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 139 END: OK
+2018-06-28 22:18:33.915 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 149 START
+2018-06-28 22:18:42.935 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 140 END: OK
+2018-06-28 22:18:42.941 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 150 START
+2018-06-28 22:18:55.958 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 141 END: OK
+2018-06-28 22:18:55.964 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 151 START
+2018-06-28 22:19:04.727 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 142 END: OK
+2018-06-28 22:19:04.733 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 152 START
+2018-06-28 22:19:11.320 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 143 END: OK
+2018-06-28 22:19:11.327 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 153 START
+2018-06-28 22:19:12.775 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 144 END: OK
+2018-06-28 22:19:12.781 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 154 START
+2018-06-28 22:19:14.147 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 145 END: OK
+2018-06-28 22:19:14.154 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 155 START
+2018-06-28 22:19:30.919 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 146 END: OK
+2018-06-28 22:19:30.924 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 156 START
+2018-06-28 22:19:39.824 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 147 END: OK
+2018-06-28 22:19:39.829 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 157 START
+2018-06-28 22:19:41.869 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 149 END: OK
+2018-06-28 22:19:41.876 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 158 START
+2018-06-28 22:19:43.164 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 148 END: OK
+2018-06-28 22:19:43.170 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 159 START
+2018-06-28 22:19:44.389 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 150 END: OK
+2018-06-28 22:19:44.396 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 160 START
+2018-06-28 22:19:59.834 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 151 END: OK
+2018-06-28 22:19:59.840 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 161 START
+2018-06-28 22:20:03.858 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 152 END: OK
+2018-06-28 22:20:03.866 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 162 START
+2018-06-28 22:20:12.892 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 153 END: OK
+2018-06-28 22:20:12.895 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 163 START
+2018-06-28 22:20:14.296 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 154 END: OK
+2018-06-28 22:20:14.303 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 164 START
+2018-06-28 22:20:15.484 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 155 END: OK
+2018-06-28 22:20:15.487 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 165 START
+2018-06-28 22:20:34.552 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 156 END: OK
+2018-06-28 22:20:34.559 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 166 START
+2018-06-28 22:20:43.193 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 157 END: OK
+2018-06-28 22:20:43.199 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 167 START
+2018-06-28 22:20:45.546 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 158 END: OK
+2018-06-28 22:20:45.552 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 168 START
+2018-06-28 22:20:49.303 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 159 END: OK
+2018-06-28 22:20:49.308 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 169 START
+2018-06-28 22:20:50.387 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 160 END: OK
+2018-06-28 22:20:50.392 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 170 START
+2018-06-28 22:21:05.817 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 161 END: OK
+2018-06-28 22:21:05.824 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 171 START
+2018-06-28 22:21:07.605 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 162 END: OK
+2018-06-28 22:21:07.610 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 172 START
+2018-06-28 22:21:15.510 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 164 END: OK
+2018-06-28 22:21:15.516 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 173 START
+2018-06-28 22:21:21.012 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 163 END: OK
+2018-06-28 22:21:21.018 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 174 START
+2018-06-28 22:21:21.458 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 165 END: OK
+2018-06-28 22:21:21.464 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 175 START
+2018-06-28 22:21:29.579 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 166 END: OK
+2018-06-28 22:21:29.587 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 176 START
+2018-06-28 22:21:40.378 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 167 END: OK
+2018-06-28 22:21:40.385 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 177 START
+2018-06-28 22:21:47.410 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 168 END: OK
+2018-06-28 22:21:47.418 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 178 START
+2018-06-28 22:21:53.708 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 170 END: OK
+2018-06-28 22:21:53.714 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 179 START
+2018-06-28 22:21:55.150 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 169 END: OK
+2018-06-28 22:21:55.157 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 180 START
+2018-06-28 22:22:09.238 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 172 END: OK
+2018-06-28 22:22:09.244 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 181 START
+2018-06-28 22:22:09.632 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 171 END: OK
+2018-06-28 22:22:09.638 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 182 START
+2018-06-28 22:22:21.611 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 173 END: OK
+2018-06-28 22:22:21.618 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 183 START
+2018-06-28 22:22:24.951 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 174 END: OK
+2018-06-28 22:22:24.959 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 184 START
+2018-06-28 22:22:27.298 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 175 END: OK
+2018-06-28 22:22:27.304 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 185 START
+2018-06-28 22:22:31.091 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 176 END: OK
+2018-06-28 22:22:31.097 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 186 START
+2018-06-28 22:22:44.124 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 177 END: OK
+2018-06-28 22:22:44.130 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 187 START
+2018-06-28 22:22:51.343 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 178 END: OK
+2018-06-28 22:22:51.349 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 188 START
+2018-06-28 22:22:57.626 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 179 END: OK
+2018-06-28 22:22:57.633 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 189 START
+2018-06-28 22:23:00.951 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 180 END: OK
+2018-06-28 22:23:00.958 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 190 START
+2018-06-28 22:23:13.543 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 182 END: OK
+2018-06-28 22:23:13.549 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 191 START
+2018-06-28 22:23:15.100 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 181 END: OK
+2018-06-28 22:23:15.106 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 192 START
+2018-06-28 22:23:23.243 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 183 END: OK
+2018-06-28 22:23:23.250 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 193 START
+2018-06-28 22:23:24.183 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 184 END: OK
+2018-06-28 22:23:24.188 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 194 START
+2018-06-28 22:23:28.342 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 185 END: OK
+2018-06-28 22:23:28.349 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 195 START
+2018-06-28 22:23:30.115 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 186 END: OK
+2018-06-28 22:23:30.121 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 196 START
+2018-06-28 22:23:45.434 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 187 END: OK
+2018-06-28 22:23:45.441 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 197 START
+2018-06-28 22:23:55.285 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 188 END: OK
+2018-06-28 22:23:55.291 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 198 START
+2018-06-28 22:23:57.343 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 189 END: OK
+2018-06-28 22:23:57.350 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 199 START
+2018-06-28 22:24:04.614 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 190 END: OK
+2018-06-28 22:24:04.621 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 200 START
+2018-06-28 22:24:17.476 21311 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 191 END: OK
+2018-06-28 22:24:21.287 21321 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 192 END: OK
+2018-06-28 22:24:27.264 21306 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 193 END: OK
+2018-06-28 22:24:27.759 21314 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 194 END: OK
+2018-06-28 22:24:29.352 21304 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 195 END: OK
+2018-06-28 22:24:29.386 21305 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 196 END: OK
+2018-06-28 22:24:35.585 21316 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 197 END: OK
+2018-06-28 22:24:41.318 21320 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 200 END: OK
+2018-06-28 22:24:43.232 21303 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 199 END: OK
+2018-06-28 22:24:43.306 21302 INFO rally.task.runner [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | ITER: 198 END: OK
+2018-06-28 22:24:43.338 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context cleanup@openstack cleanup() started
+2018-06-28 22:24:54.651 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context cleanup@openstack cleanup() finished in 11.31 sec
+2018-06-28 22:24:54.652 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context network@openstack cleanup() started
+2018-06-28 22:25:47.406 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context network@openstack cleanup() finished in 52.75 sec
+2018-06-28 22:25:47.407 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context users@openstack cleanup() started
+2018-06-28 22:25:52.678 20358 INFO rally.task.context [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Context users@openstack cleanup() finished in 5.27 sec
+2018-06-28 22:25:52.916 20358 INFO rally.task.engine [-] Load duration is: 1311.345893
+2018-06-28 22:25:52.917 20358 INFO rally.task.engine [-] Full runner duration is: 1312.402284
+2018-06-28 22:25:52.917 20358 INFO rally.task.engine [-] Full duration is: 1413.413014
+2018-06-28 22:25:53.076 20358 INFO rally.task.engine [-] Task 510f3127-60e1-484c-917d-7af7487d2305 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 510f3127-60e1-484c-917d-7af7487d2305: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_and_delete_server
+args position 0
+args values:
+{
+  "runner": {
+    "times": 200, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 5
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "image": {
+      "name": "Ubuntu 16.04"
+    }, 
+    "force_delete": false
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 510f3127-60e1-484c-917d-7af7487d2305 has 0 error(s)
+--------------------------------------------------------------------------------
+
++-----------------------------------------------------------------------------------------------------------------------+
+|                                                 Response Times (sec)                                                  |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action             | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server   | 22.665    | 51.975       | 61.416       | 68.521       | 91.616    | 52.103    | 100.0%  | 200   |
+| nova.delete_server | 2.489     | 11.696       | 16.03        | 16.325       | 18.887    | 11.758    | 100.0%  | 200   |
+| total              | 31.955    | 63.811       | 69.042       | 75.494       | 103.109   | 63.862    | 100.0%  | 200   |
+|  -> duration       | 30.955    | 62.811       | 68.042       | 74.494       | 102.109   | 62.862    | 100.0%  | 200   |
+|  -> idle_duration  | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 200   |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 1290.707258
+Full duration: 1312.010796
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_and_delete_server
+args position 0
+args values:
+{
+  "runner": {
+    "times": 200, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 5
+    }, 
+    "network": {
+      "start_cidr": "192.168.74.0/24", 
+      "networks_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.medium"
+    }, 
+    "image": {
+      "name": "Ubuntu 16.04"
+    }, 
+    "auto_assign_nic": true
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 510f3127-60e1-484c-917d-7af7487d2305 has 0 error(s)
+--------------------------------------------------------------------------------
+
++-----------------------------------------------------------------------------------------------------------------------+
+|                                                 Response Times (sec)                                                  |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action             | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server   | 22.989    | 52.155       | 65.816       | 75.331       | 84.77     | 53.344    | 100.0%  | 200   |
+| nova.delete_server | 2.451     | 13.662       | 16.023       | 16.184       | 20.848    | 11.679    | 100.0%  | 200   |
+| total              | 36.696    | 64.278       | 72.976       | 79.887       | 93.823    | 65.024    | 100.0%  | 200   |
+|  -> duration       | 35.696    | 63.278       | 71.976       | 78.887       | 92.823    | 64.024    | 100.0%  | 200   |
+|  -> idle_duration  | 1.0       | 1.0          | 1.0          | 1.0          | 1.0       | 1.0       | 100.0%  | 200   |
++--------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 1311.345893
+Full duration: 1413.413014
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 510f3127-60e1-484c-917d-7af7487d2305 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 510f3127-60e1-484c-917d-7af7487d2305 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 510f3127-60e1-484c-917d-7af7487d2305 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "NeutronNetworks.create_and_delete_ports": [
+        {
+            "args": {
+                "network_create_args": {},
+                "port_create_args": {},
+                "ports_per_network": 10
+            },
+            "runner": {
+                "type": "constant",
+                "times": 20,
+                "concurrency": 10
+            },
+            "context": {
+                "network": {},
+                "users": {
+                    "tenants": 3,
+                    "users_per_tenant": 3
+                },
+                "quotas": {
+                    "neutron": {
+                        "network": -1,
+                        "port": -1
+                    }
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  842e3f52-baad-408d-abdb-9744bd405031: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 842e3f52-baad-408d-abdb-9744bd405031
+2018-06-28 22:25:55.052 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Starting:  Task validation.
+2018-06-28 22:25:55.058 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Starting:  Task validation of syntax.
+2018-06-28 22:25:55.072 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Completed: Task validation of syntax.
+2018-06-28 22:25:55.072 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Starting:  Task validation of required platforms.
+2018-06-28 22:25:55.077 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Completed: Task validation of required platforms.
+2018-06-28 22:25:55.078 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Starting:  Task validation of semantic.
+2018-06-28 22:25:58.171 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context users@openstack setup()  finished in 2.42 sec
+2018-06-28 22:25:58.601 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context users@openstack cleanup() started
+2018-06-28 22:26:02.131 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context users@openstack cleanup() finished in 3.53 sec
+2018-06-28 22:26:02.132 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Completed: Task validation of semantic.
+2018-06-28 22:26:02.133 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Completed: Task validation.
+2018-06-28 22:26:02.133 21648 INFO rally.api [-] Task 842e3f52-baad-408d-abdb-9744bd405031 input file is valid.
+2018-06-28 22:26:02.133 21648 INFO rally.api [-] Run Task 842e3f52-baad-408d-abdb-9744bd405031 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 22:26:02.134 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Starting:  Running task.
+2018-06-28 22:26:02.181 21648 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=76213d32-7258-4f65-a30f-294f39e76f2b)", 
+   "subtasks": [
+      {
+         "title": "NeutronNetworks.create_and_delete_ports", 
+         "description": "Create and delete a port.", 
+         "scenario": {
+            "NeutronNetworks.create_and_delete_ports": {
+               "network_create_args": {}, 
+               "port_create_args": {}, 
+               "ports_per_network": 10
+            }
+         }, 
+         "contexts": {
+            "network": {}, 
+            "users": {
+               "tenants": 3, 
+               "users_per_tenant": 3
+            }, 
+            "quotas": {
+               "neutron": {
+                  "network": -1, 
+                  "port": -1
+               }
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 20, 
+               "concurrency": 10
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 22:26:05.330 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context users@openstack setup()  finished in 3.12 sec
+2018-06-28 22:26:06.059 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context quotas@openstack setup()  finished in 0.73 sec
+2018-06-28 22:26:20.317 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context network@openstack setup()  finished in 14.26 sec
+2018-06-28 22:26:20.317 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context cleanup@openstack setup()  finished in 0.02 msec
+2018-06-28 22:26:20.352 21776 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 1 START
+2018-06-28 22:26:20.353 21778 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 3 START
+2018-06-28 22:26:20.356 21779 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 4 START
+2018-06-28 22:26:20.360 21777 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 2 START
+2018-06-28 22:26:20.364 21780 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 5 START
+2018-06-28 22:26:20.365 21782 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 6 START
+2018-06-28 22:26:20.365 21786 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 7 START
+2018-06-28 22:26:20.372 21790 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 8 START
+2018-06-28 22:26:20.374 21791 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 10 START
+2018-06-28 22:26:20.373 21794 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 9 START
+2018-06-28 22:26:38.038 21779 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 4 END: OK
+2018-06-28 22:26:38.045 21779 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 11 START
+2018-06-28 22:26:39.182 21778 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 3 END: OK
+2018-06-28 22:26:39.188 21778 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 12 START
+2018-06-28 22:26:39.397 21776 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 1 END: OK
+2018-06-28 22:26:39.404 21776 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 13 START
+2018-06-28 22:26:39.938 21791 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 10 END: OK
+2018-06-28 22:26:39.943 21791 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 14 START
+2018-06-28 22:26:40.004 21794 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 9 END: OK
+2018-06-28 22:26:40.010 21794 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 15 START
+2018-06-28 22:26:40.182 21790 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 8 END: OK
+2018-06-28 22:26:40.188 21790 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 16 START
+2018-06-28 22:26:40.272 21782 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 6 END: OK
+2018-06-28 22:26:40.279 21782 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 17 START
+2018-06-28 22:26:40.434 21777 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 2 END: OK
+2018-06-28 22:26:40.440 21777 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 18 START
+2018-06-28 22:26:40.636 21780 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 5 END: OK
+2018-06-28 22:26:40.643 21780 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 19 START
+2018-06-28 22:26:41.771 21786 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 7 END: OK
+2018-06-28 22:26:41.777 21786 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 20 START
+2018-06-28 22:26:56.378 21778 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 12 END: OK
+2018-06-28 22:26:56.677 21779 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 11 END: OK
+2018-06-28 22:26:57.323 21782 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 17 END: OK
+2018-06-28 22:26:57.323 21776 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 13 END: OK
+2018-06-28 22:26:58.240 21791 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 14 END: OK
+2018-06-28 22:26:58.486 21780 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 19 END: OK
+2018-06-28 22:26:58.947 21777 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 18 END: OK
+2018-06-28 22:26:59.023 21794 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 15 END: OK
+2018-06-28 22:26:59.715 21786 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 20 END: OK
+2018-06-28 22:27:00.264 21790 INFO rally.task.runner [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | ITER: 16 END: OK
+2018-06-28 22:27:00.291 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context cleanup@openstack cleanup() started
+2018-06-28 22:27:18.805 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context cleanup@openstack cleanup() finished in 18.51 sec
+2018-06-28 22:27:18.805 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context network@openstack cleanup() started
+2018-06-28 22:27:45.963 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context network@openstack cleanup() finished in 27.16 sec
+2018-06-28 22:27:45.964 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context quotas@openstack cleanup() started
+2018-06-28 22:27:46.057 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context quotas@openstack cleanup() finished in 93.60 msec
+2018-06-28 22:27:46.058 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context users@openstack cleanup() started
+2018-06-28 22:27:51.158 21648 INFO rally.task.context [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Context users@openstack cleanup() finished in 5.10 sec
+2018-06-28 22:27:52.882 21648 INFO rally.task.engine [-] Load duration is: 39.90879
+2018-06-28 22:27:52.883 21648 INFO rally.task.engine [-] Full runner duration is: 39.966605
+2018-06-28 22:27:52.883 21648 INFO rally.task.engine [-] Full duration is: 108.968765
+2018-06-28 22:27:53.002 21648 INFO rally.task.engine [-] Task 842e3f52-baad-408d-abdb-9744bd405031 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 842e3f52-baad-408d-abdb-9744bd405031: finished
+--------------------------------------------------------------------------------
+
+test scenario NeutronNetworks.create_and_delete_ports
+args position 0
+args values:
+{
+  "runner": {
+    "times": 20, 
+    "concurrency": 10
+  }, 
+  "contexts": {
+    "network": {}, 
+    "users": {
+      "tenants": 3, 
+      "users_per_tenant": 3
+    }, 
+    "quotas": {
+      "neutron": {
+        "network": -1, 
+        "port": -1
+      }
+    }
+  }, 
+  "args": {
+    "network_create_args": {}, 
+    "port_create_args": {}, 
+    "ports_per_network": 10
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 842e3f52-baad-408d-abdb-9744bd405031 has 0 error(s)
+--------------------------------------------------------------------------------
+
++------------------------------------------------------------------------------------------------------------------------------+
+|                                                     Response Times (sec)                                                     |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                    | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| neutron.create_port (x10) | 10.264    | 11.836       | 13.437       | 13.849       | 14.433    | 12.07     | 100.0%  | 20    |
+| neutron.delete_port (x10) | 6.027     | 6.846        | 7.387        | 7.516        | 7.764     | 6.862     | 100.0%  | 20    |
+| total                     | 17.043    | 18.919       | 20.095       | 20.328       | 21.403    | 18.932    | 100.0%  | 20    |
+|  -> duration              | 17.043    | 18.919       | 20.095       | 20.328       | 21.403    | 18.932    | 100.0%  | 20    |
+|  -> idle_duration         | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 20    |
++---------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 39.90879
+Full duration: 108.968765
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 842e3f52-baad-408d-abdb-9744bd405031 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 842e3f52-baad-408d-abdb-9744bd405031 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 842e3f52-baad-408d-abdb-9744bd405031 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "CinderVolumes.create_and_extend_volume": [
+        {
+            "args": {
+                "size": 20,
+                "new_size": 50
+            },
+            "runner": {
+                "type": "constant",
+                "times": 20,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 1,
+                    "users_per_tenant": 1
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  f2e96c77-950b-4d11-a7de-44a44fade400: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: f2e96c77-950b-4d11-a7de-44a44fade400
+2018-06-28 22:27:54.889 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Starting:  Task validation.
+2018-06-28 22:27:54.896 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Starting:  Task validation of syntax.
+2018-06-28 22:27:54.906 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Completed: Task validation of syntax.
+2018-06-28 22:27:54.906 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Starting:  Task validation of required platforms.
+2018-06-28 22:27:54.911 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Completed: Task validation of required platforms.
+2018-06-28 22:27:54.911 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Starting:  Task validation of semantic.
+2018-06-28 22:27:58.086 22067 INFO rally.task.context [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Context users@openstack setup()  finished in 2.49 sec
+2018-06-28 22:27:58.605 22067 INFO rally.task.context [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Context users@openstack cleanup() started
+2018-06-28 22:28:01.998 22067 INFO rally.task.context [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Context users@openstack cleanup() finished in 3.39 sec
+2018-06-28 22:28:01.999 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Completed: Task validation of semantic.
+2018-06-28 22:28:01.999 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Completed: Task validation.
+2018-06-28 22:28:01.999 22067 INFO rally.api [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 input file is valid.
+2018-06-28 22:28:02.000 22067 INFO rally.api [-] Run Task f2e96c77-950b-4d11-a7de-44a44fade400 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 22:28:02.000 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Starting:  Running task.
+2018-06-28 22:28:02.042 22067 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=950e7926-65c6-4759-b71b-dbb9b469fbd3)", 
+   "subtasks": [
+      {
+         "title": "CinderVolumes.create_and_extend_volume", 
+         "description": "Create and extend a volume and then delete it.", 
+         "scenario": {
+            "CinderVolumes.create_and_extend_volume": {
+               "size": 20, 
+               "new_size": 50
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 1, 
+               "users_per_tenant": 1
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 20, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 22:28:04.798 22067 INFO rally.task.context [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Context users@openstack setup()  finished in 2.72 sec
+2018-06-28 22:28:04.799 22067 INFO rally.task.context [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Context cleanup@openstack setup()  finished in 0.00 msec
+2018-06-28 22:28:04.823 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 1 START
+2018-06-28 22:28:04.826 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 2 START
+2018-06-28 22:28:12.600 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 2 END: OK
+2018-06-28 22:28:12.604 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 3 START
+2018-06-28 22:28:13.617 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 1 END: OK
+2018-06-28 22:28:13.621 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 4 START
+2018-06-28 22:28:20.181 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 3 END: OK
+2018-06-28 22:28:20.184 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 5 START
+2018-06-28 22:28:21.231 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 4 END: OK
+2018-06-28 22:28:21.234 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 6 START
+2018-06-28 22:28:27.962 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 5 END: OK
+2018-06-28 22:28:27.964 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 7 START
+2018-06-28 22:28:28.792 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 6 END: OK
+2018-06-28 22:28:28.798 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 8 START
+2018-06-28 22:28:35.353 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 7 END: OK
+2018-06-28 22:28:35.358 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 9 START
+2018-06-28 22:28:36.274 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 8 END: OK
+2018-06-28 22:28:36.276 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 10 START
+2018-06-28 22:28:43.003 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 9 END: OK
+2018-06-28 22:28:43.006 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 11 START
+2018-06-28 22:28:43.889 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 10 END: OK
+2018-06-28 22:28:43.892 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 12 START
+2018-06-28 22:28:50.584 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 11 END: OK
+2018-06-28 22:28:50.587 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 13 START
+2018-06-28 22:28:51.599 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 12 END: OK
+2018-06-28 22:28:51.602 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 14 START
+2018-06-28 22:28:58.055 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 13 END: OK
+2018-06-28 22:28:58.058 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 15 START
+2018-06-28 22:28:59.125 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 14 END: OK
+2018-06-28 22:28:59.128 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 16 START
+2018-06-28 22:29:05.560 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 15 END: OK
+2018-06-28 22:29:05.563 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 17 START
+2018-06-28 22:29:06.524 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 16 END: OK
+2018-06-28 22:29:06.527 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 18 START
+2018-06-28 22:29:13.037 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 17 END: OK
+2018-06-28 22:29:13.040 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 19 START
+2018-06-28 22:29:14.065 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 18 END: OK
+2018-06-28 22:29:14.068 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 20 START
+2018-06-28 22:29:20.465 22196 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 19 END: OK
+2018-06-28 22:29:21.597 22195 INFO rally.task.runner [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | ITER: 20 END: OK
+2018-06-28 22:29:21.624 22067 INFO rally.task.context [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Context cleanup@openstack cleanup() started
+2018-06-28 22:29:23.730 22067 INFO rally.task.context [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Context cleanup@openstack cleanup() finished in 2.11 sec
+2018-06-28 22:29:23.731 22067 INFO rally.task.context [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Context users@openstack cleanup() started
+2018-06-28 22:29:27.143 22067 INFO rally.task.context [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Context users@openstack cleanup() finished in 3.41 sec
+2018-06-28 22:29:28.538 22067 INFO rally.task.engine [-] Load duration is: 76.769645
+2018-06-28 22:29:28.538 22067 INFO rally.task.engine [-] Full runner duration is: 76.817914
+2018-06-28 22:29:28.538 22067 INFO rally.task.engine [-] Full duration is: 85.094316
+2018-06-28 22:29:28.617 22067 INFO rally.task.engine [-] Task f2e96c77-950b-4d11-a7de-44a44fade400 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task f2e96c77-950b-4d11-a7de-44a44fade400: finished
+--------------------------------------------------------------------------------
+
+test scenario CinderVolumes.create_and_extend_volume
+args position 0
+args values:
+{
+  "runner": {
+    "times": 20, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 1, 
+      "users_per_tenant": 1
+    }
+  }, 
+  "args": {
+    "size": 20, 
+    "new_size": 50
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task f2e96c77-950b-4d11-a7de-44a44fade400 has 0 error(s)
+--------------------------------------------------------------------------------
+
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume | 2.802     | 2.939        | 3.052        | 3.248        | 4.189     | 3.003     | 100.0%  | 20    |
+| cinder_v2.extend_volume | 2.284     | 2.323        | 2.421        | 2.469        | 2.547     | 2.345     | 100.0%  | 20    |
+| cinder_v2.delete_volume | 2.229     | 2.253        | 2.311        | 2.324        | 2.364     | 2.267     | 100.0%  | 20    |
+| total                   | 7.387     | 7.545        | 7.771        | 7.827        | 8.79      | 7.616     | 100.0%  | 20    |
+|  -> duration            | 7.387     | 7.545        | 7.771        | 7.827        | 8.79      | 7.616     | 100.0%  | 20    |
+|  -> idle_duration       | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 20    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 76.769645
+Full duration: 85.094316
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report f2e96c77-950b-4d11-a7de-44a44fade400 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export f2e96c77-950b-4d11-a7de-44a44fade400 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report f2e96c77-950b-4d11-a7de-44a44fade400 --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+   "NovaServers.boot_and_rebuild_server": [
+        {
+            "args": {
+                "flavor": {
+                    "name": "m1.xlarge"
+                },
+                "from_image": {
+                    "name": "Debian 9"
+                },
+                "to_image": {
+                    "name": "Ubuntu 14.04 LTS"
+                }
+            },
+            "runner": {
+                "type": "constant",
+                "times": 50,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 1,
+                    "users_per_tenant": 1
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  7210ec82-b643-4b16-a1e7-a9f6e1b18abc: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 7210ec82-b643-4b16-a1e7-a9f6e1b18abc
+2018-06-28 22:29:30.407 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Starting:  Task validation.
+2018-06-28 22:29:30.414 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Starting:  Task validation of syntax.
+2018-06-28 22:29:30.424 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Completed: Task validation of syntax.
+2018-06-28 22:29:30.424 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Starting:  Task validation of required platforms.
+2018-06-28 22:29:30.429 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Completed: Task validation of required platforms.
+2018-06-28 22:29:30.429 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Starting:  Task validation of semantic.
+2018-06-28 22:29:33.537 22342 INFO rally.task.context [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Context users@openstack setup()  finished in 2.38 sec
+2018-06-28 22:29:35.692 22342 INFO rally.task.context [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Context users@openstack cleanup() started
+2018-06-28 22:29:39.026 22342 INFO rally.task.context [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Context users@openstack cleanup() finished in 3.33 sec
+2018-06-28 22:29:39.027 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Completed: Task validation of semantic.
+2018-06-28 22:29:39.027 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Completed: Task validation.
+2018-06-28 22:29:39.028 22342 INFO rally.api [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc input file is valid.
+2018-06-28 22:29:39.028 22342 INFO rally.api [-] Run Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-28 22:29:39.028 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Starting:  Running task.
+2018-06-28 22:29:39.078 22342 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=47987d32-ae11-4dae-83b4-1ef841589d6e)", 
+   "subtasks": [
+      {
+         "title": "NovaServers.boot_and_rebuild_server", 
+         "description": "Rebuild a server.", 
+         "scenario": {
+            "NovaServers.boot_and_rebuild_server": {
+               "flavor": {
+                  "name": "m1.xlarge"
+               }, 
+               "from_image": {
+                  "name": "Debian 9"
+               }, 
+               "to_image": {
+                  "name": "Ubuntu 14.04 LTS"
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 1, 
+               "users_per_tenant": 1
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 50, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-28 22:29:41.671 22342 INFO rally.task.context [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Context users@openstack setup()  finished in 2.56 sec
+2018-06-28 22:29:41.672 22342 INFO rally.task.context [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Context cleanup@openstack setup()  finished in 0.04 msec
+2018-06-28 22:29:42.499 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 1 START
+2018-06-28 22:29:42.501 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 2 START
+2018-06-28 22:36:45.383 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 2 END: OK
+2018-06-28 22:36:45.388 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 3 START
+2018-06-28 22:36:45.618 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 1 END: OK
+2018-06-28 22:36:45.623 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 4 START
+2018-06-28 22:44:06.640 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 3 END: OK
+2018-06-28 22:44:06.644 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 5 START
+2018-06-28 22:44:16.844 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 4 END: OK
+2018-06-28 22:44:16.849 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 6 START
+2018-06-28 22:51:36.682 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 5 END: OK
+2018-06-28 22:51:36.687 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 7 START
+2018-06-28 22:51:38.397 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 6 END: OK
+2018-06-28 22:51:38.401 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 8 START
+2018-06-28 22:58:40.800 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 7 END: OK
+2018-06-28 22:58:40.805 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 9 START
+2018-06-28 22:59:13.445 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 8 END: OK
+2018-06-28 22:59:13.448 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 10 START
+2018-06-28 23:05:23.621 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 10 END: OK
+2018-06-28 23:05:23.625 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 11 START
+2018-06-28 23:05:25.553 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 9 END: OK
+2018-06-28 23:05:25.557 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 12 START
+2018-06-28 23:12:22.950 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 11 END: OK
+2018-06-28 23:12:22.955 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 13 START
+2018-06-28 23:12:23.068 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 12 END: OK
+2018-06-28 23:12:23.072 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 14 START
+2018-06-28 23:18:04.407 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 14 END: OK
+2018-06-28 23:18:04.410 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 15 START
+2018-06-28 23:19:56.915 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 13 END: OK
+2018-06-28 23:19:56.919 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 16 START
+2018-06-28 23:23:50.192 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 15 END: OK
+2018-06-28 23:23:50.196 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 17 START
+2018-06-28 23:27:04.436 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 16 END: OK
+2018-06-28 23:27:04.441 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 18 START
+2018-06-28 23:30:45.003 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 17 END: OK
+2018-06-28 23:30:45.007 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 19 START
+2018-06-28 23:32:48.778 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 18 END: OK
+2018-06-28 23:32:48.782 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 20 START
+2018-06-28 23:38:14.800 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 19 END: OK
+2018-06-28 23:38:14.804 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 21 START
+2018-06-28 23:38:25.474 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 20 END: OK
+2018-06-28 23:38:25.479 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 22 START
+2018-06-28 23:43:32.478 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 22 END: OK
+2018-06-28 23:43:32.481 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 23 START
+2018-06-28 23:45:42.359 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 21 END: OK
+2018-06-28 23:45:42.363 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 24 START
+2018-06-28 23:49:48.041 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 23 END: OK
+2018-06-28 23:49:48.045 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 25 START
+2018-06-28 23:52:46.895 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 24 END: OK
+2018-06-28 23:52:46.899 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 26 START
+2018-06-28 23:56:33.179 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 25 END: OK
+2018-06-28 23:56:33.183 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 27 START
+2018-06-28 23:58:22.717 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 26 END: OK
+2018-06-28 23:58:22.721 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 28 START
+2018-06-29 00:02:53.724 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 27 END: OK
+2018-06-29 00:02:53.728 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 29 START
+2018-06-29 00:03:05.917 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 28 END: OK
+2018-06-29 00:03:05.920 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 30 START
+2018-06-29 00:07:55.048 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 29 END: OK
+2018-06-29 00:07:55.052 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 31 START
+2018-06-29 00:08:31.125 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 30 END: OK
+2018-06-29 00:08:31.129 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 32 START
+2018-06-29 00:13:15.591 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 31 END: OK
+2018-06-29 00:13:15.595 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 33 START
+2018-06-29 00:15:47.931 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 32 END: OK
+2018-06-29 00:15:47.935 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 34 START
+2018-06-29 00:18:49.251 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 33 END: OK
+2018-06-29 00:18:49.255 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 35 START
+2018-06-29 00:22:46.320 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 34 END: OK
+2018-06-29 00:22:46.324 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 36 START
+2018-06-29 00:26:21.002 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 35 END: OK
+2018-06-29 00:26:21.007 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 37 START
+2018-06-29 00:30:15.112 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 36 END: OK
+2018-06-29 00:30:15.116 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 38 START
+2018-06-29 00:33:33.372 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 37 END: OK
+2018-06-29 00:33:33.377 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 39 START
+2018-06-29 00:35:18.142 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 38 END: OK
+2018-06-29 00:35:18.145 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 40 START
+2018-06-29 00:39:22.880 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 39 END: OK
+2018-06-29 00:39:22.884 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 41 START
+2018-06-29 00:41:33.601 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 40 END: OK
+2018-06-29 00:41:33.605 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 42 START
+2018-06-29 00:45:11.272 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 41 END: OK
+2018-06-29 00:45:11.276 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 43 START
+2018-06-29 00:48:33.185 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 42 END: OK
+2018-06-29 00:48:33.189 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 44 START
+2018-06-29 00:51:03.847 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 43 END: OK
+2018-06-29 00:51:03.852 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 45 START
+2018-06-29 00:55:59.719 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 44 END: OK
+2018-06-29 00:55:59.723 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 46 START
+2018-06-29 00:57:11.849 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 45 END: OK
+2018-06-29 00:57:11.853 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 47 START
+2018-06-29 01:02:49.016 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 47 END: OK
+2018-06-29 01:02:49.020 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 48 START
+2018-06-29 01:02:49.574 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 46 END: OK
+2018-06-29 01:02:49.578 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 49 START
+2018-06-29 01:08:01.002 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 49 END: OK
+2018-06-29 01:08:01.007 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 50 START
+2018-06-29 01:08:11.576 22470 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 48 END: OK
+2018-06-29 01:13:12.586 22471 INFO rally.task.runner [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | ITER: 50 END: OK
+2018-06-29 01:13:12.610 22342 INFO rally.task.context [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Context cleanup@openstack cleanup() started
+2018-06-29 01:13:14.288 22342 INFO rally.task.context [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Context cleanup@openstack cleanup() finished in 1.68 sec
+2018-06-29 01:13:14.289 22342 INFO rally.task.context [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Context users@openstack cleanup() started
+2018-06-29 01:13:17.240 22342 INFO rally.task.context [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Context users@openstack cleanup() finished in 2.95 sec
+2018-06-29 01:13:18.193 22342 INFO rally.task.engine [-] Load duration is: 9808.084223
+2018-06-29 01:13:18.194 22342 INFO rally.task.engine [-] Full runner duration is: 9810.128278
+2018-06-29 01:13:18.195 22342 INFO rally.task.engine [-] Full duration is: 9818.151794
+2018-06-29 01:13:18.297 22342 INFO rally.task.engine [-] Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc: finished
+--------------------------------------------------------------------------------
+
+test scenario NovaServers.boot_and_rebuild_server
+args position 0
+args values:
+{
+  "runner": {
+    "times": 50, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 1, 
+      "users_per_tenant": 1
+    }
+  }, 
+  "args": {
+    "flavor": {
+      "name": "m1.xlarge"
+    }, 
+    "from_image": {
+      "name": "Debian 9"
+    }, 
+    "to_image": {
+      "name": "Ubuntu 14.04 LTS"
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 7210ec82-b643-4b16-a1e7-a9f6e1b18abc has 0 error(s)
+--------------------------------------------------------------------------------
+
++------------------------------------------------------------------------------------------------------------------------+
+|                                                  Response Times (sec)                                                  |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action              | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| nova.boot_server    | 114.874   | 187.924      | 209.348      | 211.021      | 218.405   | 177.081   | 100.0%  | 50    |
+| nova.rebuild_server | 152.768   | 215.991      | 236.373      | 237.118      | 242.493   | 205.549   | 100.0%  | 50    |
+| nova.delete_server  | 2.459     | 4.634        | 4.804        | 4.861        | 4.911     | 3.748     | 100.0%  | 50    |
+| total               | 283.195   | 404.94       | 449.816      | 451.51       | 455.042   | 386.378   | 100.0%  | 50    |
+|  -> duration        | 281.195   | 402.94       | 447.816      | 449.51       | 453.042   | 384.378   | 100.0%  | 50    |
+|  -> idle_duration   | 2.0       | 2.0          | 2.0          | 2.0          | 2.0       | 2.0       | 100.0%  | 50    |
++---------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 9808.084223
+Full duration: 9818.151794
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 7210ec82-b643-4b16-a1e7-a9f6e1b18abc --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 7210ec82-b643-4b16-a1e7-a9f6e1b18abc --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 7210ec82-b643-4b16-a1e7-a9f6e1b18abc --json --out output.json
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "SwiftObjects.create_container_and_object_then_delete_all": [
+        {
+            "args": {
+                "objects_per_container": 5,
+                "object_size": 102400
+            },
+            "runner": {
+                "type": "constant",
+                "times": 4,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 1,
+                    "users_per_tenant": 1
+                },
+                "roles": [
+                    "admin"
+                ]
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  e2b76164-a1b2-440b-950a-97dba4a9a996: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: e2b76164-a1b2-440b-950a-97dba4a9a996
+2018-06-29 01:13:20.184 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Starting:  Task validation.
+2018-06-29 01:13:20.190 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Starting:  Task validation of syntax.
+2018-06-29 01:13:20.201 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Completed: Task validation of syntax.
+2018-06-29 01:13:20.201 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Starting:  Task validation of required platforms.
+2018-06-29 01:13:20.206 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Completed: Task validation of required platforms.
+2018-06-29 01:13:20.206 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Starting:  Task validation of semantic.
+2018-06-29 01:13:23.255 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context users@openstack setup()  finished in 2.37 sec
+2018-06-29 01:13:23.697 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context users@openstack cleanup() started
+2018-06-29 01:13:26.946 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context users@openstack cleanup() finished in 3.25 sec
+2018-06-29 01:13:26.947 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Completed: Task validation of semantic.
+2018-06-29 01:13:26.947 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Completed: Task validation.
+2018-06-29 01:13:26.947 26076 INFO rally.api [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 input file is valid.
+2018-06-29 01:13:26.948 26076 INFO rally.api [-] Run Task e2b76164-a1b2-440b-950a-97dba4a9a996 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-29 01:13:26.948 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Starting:  Running task.
+2018-06-29 01:13:27.033 26076 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=5caaad19-b85d-4a26-aa97-01921f82ec9f)", 
+   "subtasks": [
+      {
+         "title": "SwiftObjects.create_container_and_object_then_delete_all", 
+         "description": "Create container and objects then delete everything created.", 
+         "scenario": {
+            "SwiftObjects.create_container_and_object_then_delete_all": {
+               "objects_per_container": 5, 
+               "object_size": 102400
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 1, 
+               "users_per_tenant": 1
+            }, 
+            "roles": [
+               "admin"
+            ]
+         }, 
+         "runner": {
+            "constant": {
+               "times": 4, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-29 01:13:29.570 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context users@openstack setup()  finished in 2.50 sec
+2018-06-29 01:13:32.448 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context roles@openstack setup()  finished in 2.88 sec
+2018-06-29 01:13:32.448 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-29 01:13:32.476 26234 INFO rally.task.runner [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | ITER: 1 START
+2018-06-29 01:13:32.478 26235 INFO rally.task.runner [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | ITER: 2 START
+2018-06-29 01:13:33.077 26235 INFO swiftclient [-] REQ: curl -i http://172.21.8.199:8080/swift/v1/a20f08e2997941abb515a56711032d51/s_rally_5caaad19_S97eIpUW -X PUT -H "Content-Length: 0" -H "X-Auth-Token: gAAAAABbNYe8Xor5..."
+2018-06-29 01:13:33.080 26235 INFO swiftclient [-] RESP STATUS: 409 Conflict
+2018-06-29 01:13:33.080 26235 INFO swiftclient [-] RESP HEADERS: {u'Content-Length': u'19', u'Accept-Ranges': u'bytes', u'X-Trans-Id': u'tx000000000000000045c10-005b3587bc-10c2-default', u'Date': u'Fri, 29 Jun 2018 01:13:33 GMT', u'Content-Type': u'text/plain; charset=utf-8', u'X-Openstack-Request-Id': u'tx000000000000000045c10-005b3587bc-10c2-default'}
+2018-06-29 01:13:33.081 26235 INFO swiftclient [-] RESP BODY: BucketAlreadyExists
+2018-06-29 01:13:33.122 26235 INFO rally.task.runner [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | ITER: 2 END: Error ClientException: Container PUT failed: http://172.21.8.199:8080/swift/v1/a20f08e2997941abb515a56711032d51/s_rally_5caaad19_S97eIpUW 409 Conflict   BucketAlreadyExists
+2018-06-29 01:13:33.126 26235 INFO rally.task.runner [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | ITER: 3 START
+2018-06-29 01:13:33.253 26234 INFO rally.task.runner [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | ITER: 1 END: OK
+2018-06-29 01:13:33.257 26234 INFO rally.task.runner [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | ITER: 4 START
+2018-06-29 01:13:33.720 26235 INFO rally.task.runner [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | ITER: 3 END: OK
+2018-06-29 01:13:33.922 26234 INFO rally.task.runner [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | ITER: 4 END: OK
+2018-06-29 01:13:33.941 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context cleanup@openstack cleanup() started
+2018-06-29 01:13:34.896 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context cleanup@openstack cleanup() finished in 0.95 sec
+2018-06-29 01:13:34.897 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context roles@openstack cleanup() started
+2018-06-29 01:13:35.899 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context roles@openstack cleanup() finished in 1.00 sec
+2018-06-29 01:13:35.900 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context users@openstack cleanup() started
+2018-06-29 01:13:39.405 26076 INFO rally.task.context [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Context users@openstack cleanup() finished in 3.51 sec
+2018-06-29 01:13:41.161 26076 INFO rally.task.engine [-] Load duration is: 1.443686
+2018-06-29 01:13:41.162 26076 INFO rally.task.engine [-] Full runner duration is: 1.486113
+2018-06-29 01:13:41.162 26076 INFO rally.task.engine [-] Full duration is: 12.363738
+2018-06-29 01:13:41.240 26076 INFO rally.task.engine [-] Task e2b76164-a1b2-440b-950a-97dba4a9a996 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task e2b76164-a1b2-440b-950a-97dba4a9a996: finished
+--------------------------------------------------------------------------------
+
+test scenario SwiftObjects.create_container_and_object_then_delete_all
+args position 0
+args values:
+{
+  "runner": {
+    "times": 4, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 1, 
+      "users_per_tenant": 1
+    }, 
+    "roles": [
+      "admin"
+    ]
+  }, 
+  "args": {
+    "objects_per_container": 5, 
+    "object_size": 102400
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task e2b76164-a1b2-440b-950a-97dba4a9a996 has 1 error(s)
+--------------------------------------------------------------------------------
+
+ClientException: Container PUT failed: http://172.21.8.199:8080/swift/v1/a20f08e2997941abb515a56711032d51/s_rally_5caaad19_S97eIpUW 409 Conflict   BucketAlreadyExists
+
+Traceback (most recent call last):
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/runner.py", line 71, in _run_scenario_once
+    getattr(scenario_inst, method_name)(**scenario_kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/swift/objects.py", line 73, in run
+    container_name = self._create_container(**kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/task/atomic.py", line 91, in func_atomic_actions
+    f = func(self, *args, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/rally/plugins/openstack/scenarios/swift/utils.py", line 50, in _create_container
+    self.clients("swift").put_container(container_name, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/swiftclient/client.py", line 1760, in put_container
+    query_string=query_string)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/swiftclient/client.py", line 1678, in _retry
+    service_token=self.service_token, **kwargs)
+  File "/home/leon0944/rally/local/lib/python2.7/site-packages/swiftclient/client.py", line 1026, in put_container
+    raise ClientException.from_response(resp, 'Container PUT failed', body)
+ClientException: Container PUT failed: http://172.21.8.199:8080/swift/v1/a20f08e2997941abb515a56711032d51/s_rally_5caaad19_S97eIpUW 409 Conflict   BucketAlreadyExists
+
+--------------------------------------------------------------------------------
++-----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                     |
++--------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                   | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++--------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| swift.create_container   | 0.44      | 0.558        | 0.607        | 0.609        | 0.611     | 0.542     | 75.0%   | 4     |
+| swift.upload_object (x5) | 0.063     | 0.072        | 0.073        | 0.073        | 0.073     | 0.069     | 100.0%  | 3     |
+| swift.delete_object (x5) | 0.056     | 0.057        | 0.06         | 0.06         | 0.06      | 0.058     | 100.0%  | 3     |
+| swift.delete_container   | 0.024     | 0.024        | 0.025        | 0.025        | 0.026     | 0.025     | 100.0%  | 3     |
+| total                    | 0.593     | 0.633        | 0.742        | 0.758        | 0.775     | 0.659     | 75.0%   | 4     |
+|  -> duration             | 0.593     | 0.633        | 0.742        | 0.758        | 0.775     | 0.659     | 75.0%   | 4     |
+|  -> idle_duration        | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 75.0%   | 4     |
++--------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 1.443686
+Full duration: 12.363738
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report e2b76164-a1b2-440b-950a-97dba4a9a996 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export e2b76164-a1b2-440b-950a-97dba4a9a996 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report e2b76164-a1b2-440b-950a-97dba4a9a996 --json --out output.json
+
+At least one workload did not pass SLA criteria.
+
+--------------------------------------------------------------------------------
+Preparing input task
+--------------------------------------------------------------------------------
+
+Task is:
+{
+    "CinderVolumes.create_volume": [
+        {
+            "args": {
+                "size": 1
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 2,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        },
+        {
+            "args": {
+                "size": {
+                    "min": 20,
+                    "max": 50
+                }
+            },
+            "runner": {
+                "type": "constant",
+                "times": 10,
+                "concurrency": 2
+            },
+            "context": {
+                "users": {
+                    "tenants": 2,
+                    "users_per_tenant": 2
+                }
+            },
+            "sla": {
+                "failure_rate": {
+                    "max": 0
+                }
+            }
+        }
+    ]
+}
+
+Task syntax is correct :)
+Running Rally version 0.10.1~dev119
+--------------------------------------------------------------------------------
+Task  59555ebc-859c-496d-92e4-584af507ef36: started
+--------------------------------------------------------------------------------
+
+Running Task... This can take a while...
+
+To track task status use:
+
+	rally task status
+	or
+	rally task detailed
+
+Using task: 59555ebc-859c-496d-92e4-584af507ef36
+2018-06-29 01:13:42.985 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Starting:  Task validation.
+2018-06-29 01:13:42.992 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Starting:  Task validation of syntax.
+2018-06-29 01:13:43.011 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Completed: Task validation of syntax.
+2018-06-29 01:13:43.011 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Starting:  Task validation of required platforms.
+2018-06-29 01:13:43.020 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Completed: Task validation of required platforms.
+2018-06-29 01:13:43.020 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Starting:  Task validation of semantic.
+2018-06-29 01:13:45.829 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context users@openstack setup()  finished in 2.22 sec
+2018-06-29 01:13:46.733 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context users@openstack cleanup() started
+2018-06-29 01:13:50.016 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context users@openstack cleanup() finished in 3.28 sec
+2018-06-29 01:13:50.016 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Completed: Task validation of semantic.
+2018-06-29 01:13:50.017 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Completed: Task validation.
+2018-06-29 01:13:50.017 26355 INFO rally.api [-] Task 59555ebc-859c-496d-92e4-584af507ef36 input file is valid.
+2018-06-29 01:13:50.017 26355 INFO rally.api [-] Run Task 59555ebc-859c-496d-92e4-584af507ef36 against Deployment 7a37a5af-20ae-460e-97c7-4fdb337cc0b6
+2018-06-29 01:13:50.018 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Starting:  Running task.
+2018-06-29 01:13:50.071 26355 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=14764a1f-85b3-4024-8b50-c77bafc35f92)", 
+   "subtasks": [
+      {
+         "title": "CinderVolumes.create_volume", 
+         "description": "Create a volume.", 
+         "scenario": {
+            "CinderVolumes.create_volume": {
+               "size": 1
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 2, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-29 01:13:52.756 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context users@openstack setup()  finished in 2.64 sec
+2018-06-29 01:13:52.757 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-29 01:13:52.784 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 1 START
+2018-06-29 01:13:52.786 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 2 START
+2018-06-29 01:13:55.992 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 1 END: OK
+2018-06-29 01:13:55.996 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 3 START
+2018-06-29 01:13:56.013 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 2 END: OK
+2018-06-29 01:13:56.017 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 4 START
+2018-06-29 01:13:58.919 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 3 END: OK
+2018-06-29 01:13:58.922 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 5 START
+2018-06-29 01:13:59.149 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 4 END: OK
+2018-06-29 01:13:59.152 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 6 START
+2018-06-29 01:14:01.863 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 5 END: OK
+2018-06-29 01:14:01.866 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 7 START
+2018-06-29 01:14:02.014 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 6 END: OK
+2018-06-29 01:14:02.017 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 8 START
+2018-06-29 01:14:04.692 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 7 END: OK
+2018-06-29 01:14:04.696 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 9 START
+2018-06-29 01:14:04.900 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 8 END: OK
+2018-06-29 01:14:04.904 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 10 START
+2018-06-29 01:14:07.532 26483 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 9 END: OK
+2018-06-29 01:14:07.811 26484 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 10 END: OK
+2018-06-29 01:14:07.840 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context cleanup@openstack cleanup() started
+2018-06-29 01:14:16.934 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context cleanup@openstack cleanup() finished in 9.09 sec
+2018-06-29 01:14:16.935 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context users@openstack cleanup() started
+2018-06-29 01:14:21.487 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context users@openstack cleanup() finished in 4.55 sec
+2018-06-29 01:14:22.294 26355 INFO rally.task.engine [-] Load duration is: 15.023031
+2018-06-29 01:14:22.294 26355 INFO rally.task.engine [-] Full runner duration is: 15.076265
+2018-06-29 01:14:22.295 26355 INFO rally.task.engine [-] Full duration is: 31.404593
+2018-06-29 01:14:22.368 26355 INFO rally.task.engine [-] Running workload: 
+  position = 0
+  config = {
+   "version": 2, 
+   "title": "A cropped version of a bigger task.", 
+   "description": "Auto-generated task from a single workload (uuid=d468899f-5a15-4661-b314-6b7dd8a9c909)", 
+   "subtasks": [
+      {
+         "title": "CinderVolumes.create_volume", 
+         "description": "Create a volume.", 
+         "scenario": {
+            "CinderVolumes.create_volume": {
+               "size": {
+                  "min": 20, 
+                  "max": 50
+               }
+            }
+         }, 
+         "contexts": {
+            "users": {
+               "tenants": 2, 
+               "users_per_tenant": 2
+            }
+         }, 
+         "runner": {
+            "constant": {
+               "times": 10, 
+               "concurrency": 2
+            }
+         }, 
+         "hooks": [], 
+         "sla": {
+            "failure_rate": {
+               "max": 0
+            }
+         }
+      }
+   ]
+}
+2018-06-29 01:14:24.978 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context users@openstack setup()  finished in 2.58 sec
+2018-06-29 01:14:24.979 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context cleanup@openstack setup()  finished in 0.01 msec
+2018-06-29 01:14:25.005 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 1 START
+2018-06-29 01:14:25.008 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 2 START
+2018-06-29 01:14:28.088 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 2 END: OK
+2018-06-29 01:14:28.092 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 3 START
+2018-06-29 01:14:28.104 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 1 END: OK
+2018-06-29 01:14:28.109 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 4 START
+2018-06-29 01:14:31.132 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 4 END: OK
+2018-06-29 01:14:31.136 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 5 START
+2018-06-29 01:14:31.193 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 3 END: OK
+2018-06-29 01:14:31.197 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 6 START
+2018-06-29 01:14:34.126 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 5 END: OK
+2018-06-29 01:14:34.130 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 7 START
+2018-06-29 01:14:34.132 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 6 END: OK
+2018-06-29 01:14:34.136 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 8 START
+2018-06-29 01:14:36.994 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 7 END: OK
+2018-06-29 01:14:36.997 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 9 START
+2018-06-29 01:14:37.069 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 8 END: OK
+2018-06-29 01:14:37.072 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 10 START
+2018-06-29 01:14:39.892 26661 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 9 END: OK
+2018-06-29 01:14:40.124 26662 INFO rally.task.runner [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | ITER: 10 END: OK
+2018-06-29 01:14:40.147 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context cleanup@openstack cleanup() started
+2018-06-29 01:14:48.340 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context cleanup@openstack cleanup() finished in 8.19 sec
+2018-06-29 01:14:48.341 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context users@openstack cleanup() started
+2018-06-29 01:14:52.422 26355 INFO rally.task.context [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Context users@openstack cleanup() finished in 4.08 sec
+2018-06-29 01:14:52.577 26355 INFO rally.task.engine [-] Load duration is: 15.114704
+2018-06-29 01:14:52.577 26355 INFO rally.task.engine [-] Full runner duration is: 15.16094
+2018-06-29 01:14:52.578 26355 INFO rally.task.engine [-] Full duration is: 30.047041
+2018-06-29 01:14:52.634 26355 INFO rally.task.engine [-] Task 59555ebc-859c-496d-92e4-584af507ef36 | Completed: Running task.
+
+--------------------------------------------------------------------------------
+Task 59555ebc-859c-496d-92e4-584af507ef36: finished
+--------------------------------------------------------------------------------
+
+test scenario CinderVolumes.create_volume
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 2, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "size": 1
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 59555ebc-859c-496d-92e4-584af507ef36 has 0 error(s)
+--------------------------------------------------------------------------------
+
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume | 2.825     | 2.913        | 3.205        | 3.214        | 3.222     | 2.972     | 100.0%  | 10    |
+| total                   | 2.825     | 2.913        | 3.206        | 3.214        | 3.223     | 2.972     | 100.0%  | 10    |
+|  -> duration            | 2.825     | 2.913        | 3.206        | 3.214        | 3.223     | 2.972     | 100.0%  | 10    |
+|  -> idle_duration       | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 10    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 15.023031
+Full duration: 31.404593
+--------------------------------------------------------------------------------
+
+test scenario CinderVolumes.create_volume
+args position 0
+args values:
+{
+  "runner": {
+    "times": 10, 
+    "concurrency": 2
+  }, 
+  "contexts": {
+    "users": {
+      "tenants": 2, 
+      "users_per_tenant": 2
+    }
+  }, 
+  "args": {
+    "size": {
+      "min": 20, 
+      "max": 50
+    }
+  }, 
+  "sla": {
+    "failure_rate": {
+      "max": 0
+    }
+  }, 
+  "hooks": []
+}
+
+--------------------------------------------------------------------------------
+Task 59555ebc-859c-496d-92e4-584af507ef36 has 0 error(s)
+--------------------------------------------------------------------------------
+
++----------------------------------------------------------------------------------------------------------------------------+
+|                                                    Response Times (sec)                                                    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| Action                  | Min (sec) | Median (sec) | 90%ile (sec) | 95%ile (sec) | Max (sec) | Avg (sec) | Success | Count |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+| cinder_v2.create_volume | 2.862     | 3.005        | 3.096        | 3.098        | 3.099     | 2.995     | 100.0%  | 10    |
+| total                   | 2.862     | 3.005        | 3.096        | 3.098        | 3.1       | 2.995     | 100.0%  | 10    |
+|  -> duration            | 2.862     | 3.005        | 3.096        | 3.098        | 3.1       | 2.995     | 100.0%  | 10    |
+|  -> idle_duration       | 0.0       | 0.0          | 0.0          | 0.0          | 0.0       | 0.0       | 100.0%  | 10    |
++-------------------------+-----------+--------------+--------------+--------------+-----------+-----------+---------+-------+
+
+Load duration: 15.114704
+Full duration: 30.047041
+
+HINTS:
+* To plot HTML graphics with this data, run:
+	rally task report 59555ebc-859c-496d-92e4-584af507ef36 --out output.html
+
+* To generate a JUnit report, run:
+	rally task export 59555ebc-859c-496d-92e4-584af507ef36 --type junit --to output.xml
+
+* To get raw JSON output of task results, run:
+	rally task report 59555ebc-859c-496d-92e4-584af507ef36 --json --out output.json
+


### PR DESCRIPTION
- updating boot-and-migrate task to use a lower flavor and less concurrency
- updating a cinder task to use lower flavors to avoid the no host available
  failure related to env limitations
- updating two heat tasks to use the correct templates
- publishing the serial suite latest results for Queens 17.1.0