### PR TITLE
RE-1602: embed-env: Modify for testing against embedded environment

### DIFF
--- a/rpc_soak_tests/rpc_rally/embedded/boot-from-volume-snapshot.json
+++ b/rpc_soak_tests/rpc_rally/embedded/boot-from-volume-snapshot.json
@@ -15,7 +15,7 @@
             },
             "runner": {
                 "type": "constant",
-                "times": 10,
+                "times": 5,
                 "concurrency": 2
             },
             "context": {

--- a/rpc_soak_tests/rpc_rally/embedded/boot-server-attach-created-volume-and-live-migrate.json
+++ b/rpc_soak_tests/rpc_rally/embedded/boot-server-attach-created-volume-and-live-migrate.json
@@ -4,7 +4,7 @@
         {
             "args": {
                 "size": 8,
-                "block_migration": false,
+                "block_migration": true,
                 "image": {
                     "name": "Ubuntu 14.04 LTS"
                 },

--- a/rpc_soak_tests/rpc_rally/embedded/create-and-attach-volume.json
+++ b/rpc_soak_tests/rpc_rally/embedded/create-and-attach-volume.json
@@ -39,7 +39,7 @@
                     "max": 20
                 },
                 "flavor": {
-                    "name": "m1.large"
+                    "name": "m1.medium"
                 },
                 "image": {
                     "name": "Ubuntu 16.04"

--- a/rpc_soak_tests/rpc_rally/embedded/create-and-restore-volume-backup.json
+++ b/rpc_soak_tests/rpc_rally/embedded/create-and-restore-volume-backup.json
@@ -17,7 +17,7 @@
                     "tenants": 1,
                     "users_per_tenant": 1
                 },
-                "roles": ["Member"]
+                "roles": ["swiftoperator"]
             },
             "sla": {
                 "failure_rate": {


### PR DESCRIPTION
* boot-from-volume-snapshot.json
  * `"times": 10,` => `"times": 5,`
    * Default project volume quota is 10 for a default RPC-O deployment.
    * NovaServers.boot_server_from_volume_snapshot scenario randomly
      chooses a user and creates two volumes each iteration.
    * If users from the same project are chosen more than 5 times,
      then the project's volume quota is exceeded and the test fails.
* boot-server-attach-created-volume-and-live-migrate.json
  * `"block_migration": false,` => `"block_migration": true,`
    * The current embedded environment configuration does not provide
      shared storage (eg Ceph, NFS) for server ephemeral disks, so
      therefor live-migrations require block migrations.
    * Rally does not support Nova API micro-versions otherwise `auto`
      could be specified with micro-version 2.25.
* create-and-attach-volume.json
  * `"name": "m1.large"` => `"name": "m1.medium"`
    * Default project core quota is 20 for a default RPC-O deployment.
    * CinderVolumes.create_and_attach_volume scenario randomly chooses
      a user and creates a server each iteration.
    * If two concurrent iterations involve the same project and create
      servers of flavor m1.large, which is a total of 24 cores (ie 12
      cores * 2 instances = 24 cores), then the project's core quota
      is exceeded and one of the iterations fails.
* create-and-restore-volume-backup.json
  * `Member` => `swiftoperator`
    * Default RPC-O deployment is not configured to allow the `Member`
      role, but instead the `swiftoperator` role, to operate on Swift
      as required by the
      `CinderVolumes.create_and_restore_volume_backup` scenario.

https://rpc-openstack.atlassian.net/browse/RE-1602