### PR TITLE
RPC Soak Test Framework initial common modules

### DIFF
--- a/rpc_soak_tests/common/__init__.py
+++ b/rpc_soak_tests/common/__init__.py
@@ -1,0 +1,15 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""

--- a/rpc_soak_tests/common/config.py
+++ b/rpc_soak_tests/common/config.py
@@ -1,0 +1,58 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+
+from rpc_soak_tests.common.exceptions import InvalidTypeException
+
+# OPENSTACK_CLOUD: value should be the cloud name in clouds.yaml
+# see the clouds_example.yaml file.
+# PROJECT_NAME: project name start with this value, by default is tempest*
+# and this is used by utils.py methods.
+
+DEFAULT_ENVIRONMENT_VARIABLES = ['OPENSTACK_CLOUD', 'PROJECT_NAME']
+
+
+class Config(object):
+    """
+    Class to define environment variables used. These will define
+    the attributes of the Config objects.
+    """
+    def __init__(self, variables=None):
+        """
+        :param list(str) variables: list of environment variable names.
+        """
+
+        # Defining default variables if not given.
+        if not variables:
+            self.variables = DEFAULT_ENVIRONMENT_VARIABLES
+        else:
+            data_type = type(variables)
+
+            # Verifing that the input varables given are in a list
+            if data_type != list:
+                msg = 'Expecting a list instead of {0} for variables'.format(
+                    data_type)
+                raise InvalidTypeException(msg)
+            else:
+                self.variables = variables
+
+        self.set_values()
+
+    def set_values(self):
+        for var in self.variables:
+            value = os.environ.get(var)
+            attr_name = var.lower()
+            setattr(self, attr_name, value)

--- a/rpc_soak_tests/common/exceptions.py
+++ b/rpc_soak_tests/common/exceptions.py
@@ -1,0 +1,37 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+class SoakTestException(Exception):
+    message = 'Not Set'
+
+    def __init__(self, message=None):
+        self.message = message or self.message
+
+    def __str__(self):
+        return str(self.message)
+
+
+class InvalidTypeException(SoakTestException):
+    message = 'Invalid data type exception'
+
+
+class UnableToDeleteResource(SoakTestException):
+    message = 'Unable to delete resource'
+
+
+class MissingDeleteParams(SoakTestException):
+    message = 'Project IDs or resources names missing'

--- a/rpc_soak_tests/common/sdks/__init__.py
+++ b/rpc_soak_tests/common/sdks/__init__.py
@@ -1,0 +1,15 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""

--- a/rpc_soak_tests/common/sdks/base.py
+++ b/rpc_soak_tests/common/sdks/base.py
@@ -1,0 +1,188 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import openstack
+
+from rpc_soak_tests.common.config import Config
+from rpc_soak_tests.common.exceptions import (MissingDeleteParams,
+                                              UnableToDeleteResource)
+
+
+# resource types
+LOAD_BALANCERS = 'load_balancers'
+NETWORKS = 'networks'
+PORTS = 'ports'
+PROJECTS = 'projects'
+SECURITY_GROUPS = 'security_groups'
+SERVERS = 'servers'
+USERS = 'users'
+
+# resource_type is in plural, this dict should provide singular forms
+SINGULAR = dict(load_balancers='load_balancer', networks='network',
+                ports='port', projects='project',
+                security_groups='security_group', servers='server',
+                users='user')
+
+
+class BaseSDK(object):
+    """
+    Base class for the SDK openstack wrappers
+    These methods are to be called by child classes, SDKs, that define the
+    self.client attribute.
+    """
+    def __init__(self, config_variables=None):
+        """
+        :param list(str) config_variables: list of environment variable names
+            for the self.config object. If not given defaults from the Config
+            module will be used.
+        """
+        self.config = Config(variables=config_variables)
+        self.conn = openstack.connect(cloud=self.config.openstack_cloud)
+
+    def get_project_id_label(self, resource_type):
+        """
+        Gets the project ID label for the resource type. For ex. a user object
+        has the attribute default_project_id but a project object has only
+        the attribute id while all the others, or most, have the project_id
+        attribute name for their corresponding project ID.
+
+        :param str resource_type: users, projects, networks, servers, etc.
+        :rtype: str
+        :return: project ID attribute label of the resource_type object
+        """
+        if resource_type in ['users']:
+            project_id_label = 'default_project_id'
+        elif resource_type in ['projects']:
+            project_id_label = 'id'
+        else:
+            project_id_label = 'project_id'
+
+        return project_id_label
+
+    def get_resource_ids(self, resource_type, project_ids=None, name=None):
+        """
+        Get resource IDs.
+
+        :param str resource_type: resources to get, for ex. loadbalancers,
+            networks, users, projects, etc.
+        :param list project_ids: only get resources within these projects.
+            NOT to be used if the resource_type is projects since it's
+            redundant and throws an invalid query param.
+        :param str name: name prefix or complete name
+        :rtype: list(str)
+        :return: list of resource IDs.
+        """
+        resources = self.get_resources(resource_type=resource_type,
+                                       project_ids=project_ids, name=name)
+
+        result = []
+        for resource in resources:
+            result.append(resource.id)
+
+        return result
+
+    def get_resources(self, resource_type, project_ids=None, name=None):
+        """
+        Get OpenStack resources within projects, with names or ALL.
+
+        :param str resource_type: resources to get, for ex. loadbalancers,
+            networks, users, projects, etc.
+        :param list project_ids: only get resources within these projects.
+        :param str name: name prefix or complete name
+        :rtype: list(openstack resource instance)
+        :return: list of resources within the projects given and/or
+            that match name (all if project_ids and name not given).
+        """
+        resources = []
+
+        if project_ids:
+            project_id_label = self.get_project_id_label(resource_type)
+
+            for project_id in project_ids:
+                kwargs = {project_id_label: project_id}
+                resp = getattr(self.client, resource_type)(**kwargs)
+                resources.extend(list(resp))
+        else:
+            resp = getattr(self.client, resource_type)()
+            resources.extend(list(resp))
+
+        if not name:
+            result = resources
+        else:
+            result = []
+            for resource in resources:
+                if resource.name.startswith(name):
+                    result.append(resource)
+
+        return result
+
+    def delete_resources(self, resource_type, project_ids=None, name=None,
+                         print_delete=False, raise_exception=False, all=False):
+        """
+        Delete OpenStack resources within projects, by name or All.
+
+        :param str resource_type: resources to get, for ex. loadbalancers,
+            networks, users, projects, etc.
+        :param list project_ids: only get resources within these projects.
+        :param str name: name(starts with) to filter resources to delete.
+        :param bool print_delete: print the resource name and ID.
+        :param bool raise_exception: flag to raise an Exception if True.
+        :param bool all: if set and no project_ids or name given it will try
+            to delete ALL resources (use with caution).
+        :rtype: dict
+        :return: list of undeleted resources.
+        :raises: UnableToDeleteResource exception if raise_exception True.
+        """
+
+        if not project_ids and not name and not all:
+            msg = ('Project IDs or resource names are missing and needed for '
+                   'deleting OpenStack cloud resources.')
+            raise MissingDeleteParams(msg)
+
+        resources = self.get_resources(resource_type=resource_type,
+                                       project_ids=project_ids, name=name)
+
+        # singular resource type name, for ex. network, port, etc.
+        type_name = SINGULAR[resource_type]
+        delete_fn = 'delete_{0}'.format(type_name)
+        undeleted_resources = []
+        project_id_label = None
+
+        if print_delete:
+            project_id_label = self.get_project_id_label(resource_type)
+
+        for resource in resources:
+            try:
+                resp = getattr(self.client, delete_fn)(resource)
+                if print_delete:
+                    project_id = getattr(resource, project_id_label)
+                    msg = ('Deleted {0} {1} with ID {2} from project '
+                           '{3}').format(type_name, resource.name,
+                                         resource.id, project_id)
+                    print(msg)
+            except Exception as e:
+                if raise_exception:
+                    raise UnableToDeleteResource(e.message)
+                else:
+                    undeleted_resources.append(resource.id)
+                    if print_delete:
+                        project_id = getattr(resource, project_id_label)
+                        msg = ('Unable to delete {0} {1} with ID {2} from '
+                               'project {3}').format(type_name, resource.name,
+                                                     resource.id, project_id)
+                        print(msg)
+
+        return undeleted_resources

--- a/rpc_soak_tests/common/sdks/clouds_example.yaml
+++ b/rpc_soak_tests/common/sdks/clouds_example.yaml
@@ -1,0 +1,31 @@
+# This file is just an example, a new file in the ~/.config/openstack
+# directory should be created with the clouds.yaml name. For more info,
+# https://docs.openstack.org/openstacksdk/latest/user/config/configuration.html
+# The SDK clients will be set with the cloud given in the env variable
+# OPENSTACK_CLOUD, for ex. export OPENSTACK_CLOUD=deimos_internal
+
+clouds:
+ phobos:
+   region_name: RegionOne
+   verify: False
+   identity_api_version: 3
+   api_timeout: 7
+   auth:
+     username: 'admin'
+     password: '<adminPass>'
+     project_name: 'admin'
+     user_domain_id: 'default'
+     project_domain_id: 'default'
+     auth_url: 'https://<IPAddress>:5000/v3/'
+  deimos_internal:
+   region_name: RegionOne
+   verify: False
+   identity_api_version: 3
+   api_timeout: 7
+   auth:
+     username: 'admin'
+     password: '<adminPass>'
+     project_name: 'admin'
+     user_domain_id: 'default'
+     project_domain_id: 'default'
+     auth_url: 'http://172.21.8.199:5000/v3/'

--- a/rpc_soak_tests/common/sdks/compute.py
+++ b/rpc_soak_tests/common/sdks/compute.py
@@ -1,0 +1,39 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from rpc_soak_tests.common.sdks.base import BaseSDK, SERVERS
+
+
+class ComputeSDK(BaseSDK):
+    """
+    Wrapper for interacting with the OpenStack compute SDK
+    """
+    def __init__(self):
+        super(ComputeSDK, self).__init__()
+        self.client = self.conn.compute
+
+    def get_servers(self, project_ids=None, name=None):
+        """
+        Get the OpenStack cloud servers
+
+        :param list project_ids: get only servers within these projects.
+        :param str name: server name prefix or complete name.
+        :rtype: list(ServerDetail)
+        :return: list of servers(s).
+        """
+        result = self.get_resources(resource_type=SERVERS,
+                                    project_ids=project_ids, name=name)
+        return result

--- a/rpc_soak_tests/common/sdks/identity.py
+++ b/rpc_soak_tests/common/sdks/identity.py
@@ -1,0 +1,50 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from rpc_soak_tests.common.sdks.base import BaseSDK, PROJECTS, USERS
+
+
+class IdentitySDK(BaseSDK):
+    """
+    Wrapper for interacting with the openstack identity SDK
+    """
+    def __init__(self):
+        super(IdentitySDK, self).__init__()
+        self.client = self.conn.identity
+
+    def get_users(self, project_ids=None, name=None):
+        """
+        Get the OpenStack cloud users
+
+        :param list project_ids: get only the users within these IDs.
+        :param str name: user name prefix or complete name
+        :return: list of user(s) that match name, if given, if not all.
+        """
+        result = self.get_resources(resource_type=USERS,
+                                    project_ids=project_ids, name=name)
+        return result
+
+    def get_projects(self, project_ids=None, name=None):
+        """
+        Get the OpenStack cloud projects
+
+        :param list project_ids: get only the projects within these IDs.
+        :param str name: project name prefix or complete name.
+        :return: list of project(s) that match name, if given, if not all.
+        """
+        result = self.get_resources(resource_type=PROJECTS,
+                                    project_ids=project_ids, name=name)
+        return result

--- a/rpc_soak_tests/common/sdks/load_balancer.py
+++ b/rpc_soak_tests/common/sdks/load_balancer.py
@@ -1,0 +1,39 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from rpc_soak_tests.common.sdks.base import BaseSDK, LOAD_BALANCERS
+
+
+class LoadBalancerSDK(BaseSDK):
+    """
+    Wrappers for interacting with the OpenStack Load Balancer SDK
+    """
+    def __init__(self):
+        super(LoadBalancerSDK, self).__init__()
+        self.client = self.conn.load_balancer
+
+    def get_load_balancers(self, project_ids=None, name=None):
+        """
+        Get the OpenStack cloud load balancers
+
+        :param list project_ids: get only networks within these projects.
+        :param str name: lb name prefix or complete name.
+        :rtype: list(LoadBalancer)
+        :return: list of load balancer(s).
+        """
+        result = self.get_resources(resource_type=LOAD_BALANCERS,
+                                    project_ids=project_ids, name=name)
+        return result

--- a/rpc_soak_tests/common/sdks/network.py
+++ b/rpc_soak_tests/common/sdks/network.py
@@ -1,0 +1,66 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from rpc_soak_tests.common.sdks.base import (BaseSDK, NETWORKS, PORTS,
+                                             SECURITY_GROUPS)
+
+
+class NetworkSDK(BaseSDK):
+    """
+    Wrapper for interacting with the openstack network SDK
+    """
+    def __init__(self):
+        super(NetworkSDK, self).__init__()
+        self.client = self.conn.network
+
+    def get_networks(self, project_ids=None, name=None):
+        """
+        Get the OpenStack cloud networks
+
+        :param list project_ids: get only networks within these projects.
+        :param str name: network name prefix or complete name.
+        :rtype: list(Network)
+        :return: list of networks(s).
+        """
+        result = self.get_resources(resource_type=NETWORKS,
+                                    project_ids=project_ids, name=name)
+        return result
+
+    def get_ports(self, project_ids=None, name=None):
+        """
+        Get the OpenStack cloud ports
+
+        :param list project_ids: get only ports within these projects.
+        :param str name: port name prefix or complete name
+        :rtype: list(PORT)
+        :return: list of ports(s).
+        """
+        result = self.get_resources(resource_type=PORTS,
+                                    project_ids=project_ids, name=name)
+        return result
+
+    def get_security_groups(self, project_ids=None, name=None):
+        """
+        Get the OpenStack cloud security_groups
+
+        :param list project_ids: get only security groups within these projects
+        :param str name: security_group name prefix or complete name
+        :rtype: list(SecurityGroup)
+        :return: list of security_groups(s)
+        """
+        result = self.get_resources(resource_type=SECURITY_GROUPS,
+                                    project_ids=project_ids, name=name)
+        return result

--- a/rpc_soak_tests/common/utils.py
+++ b/rpc_soak_tests/common/utils.py
@@ -1,0 +1,295 @@
+"""
+Copyright 2018 Rackspace
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from rpc_soak_tests.common.sdks.base import (LOAD_BALANCERS, NETWORKS, PORTS,
+                                             PROJECTS, SECURITY_GROUPS,
+                                             SERVERS, USERS)
+from rpc_soak_tests.common.sdks.base import BaseSDK
+from rpc_soak_tests.common.sdks.compute import ComputeSDK
+from rpc_soak_tests.common.sdks.identity import IdentitySDK
+from rpc_soak_tests.common.sdks.network import NetworkSDK
+from rpc_soak_tests.common.sdks.load_balancer import LoadBalancerSDK
+
+
+DEFAULT_PROJECT_NAME = 'tempest'
+
+
+class Utils(object):
+    """
+    Common utilities for interacting with the OpenStack SDK wrappers, for ex.
+
+    from rpc_soak_tests.common.utils import Utils
+
+    # os.environ calls NOT needed if set as env variables
+    # See the clouds_example.yaml file to create the clouds.yaml file
+    os.environ['OPENSTACK_CLOUD'] = 'deimos_internal'
+
+    # Project to be used by DELETE methods. Not needed if tempest
+    # is used since is the default as seen above (this is just an ex.)
+    os.environ['PROJECT_NAME'] = 'tempest'
+
+    utils = Utils()
+    projects = utils.identity.get_projects()
+    networks = utils.network.get_networks()
+    undeleted_networks = utils.delete_networks()
+    """
+    def __init__(self, project_name=None):
+        self.base = BaseSDK()
+        self.compute = ComputeSDK()
+        self.identity = IdentitySDK()
+        self.network = NetworkSDK()
+        self.loadbalancer = LoadBalancerSDK()
+
+        # Making accesible the OpenStack connection object
+        self.conn = self.identity.conn
+
+        # Project name starts with
+        self.project_name = (project_name or self.base.config.project_name or
+                             DEFAULT_PROJECT_NAME)
+
+    def get_project_ids(self, name=None):
+        """
+        Get project IDs by name
+
+        :param str name: project name prefix or complete name
+        :rtype: list(str)
+        :return: list of project IDs
+        """
+        name = name or self.project_name
+
+        result = self.identity.get_resource_ids(
+            resource_type=PROJECTS, name=name)
+
+        return result
+
+    def get_deleted_project_ids(self, name=None):
+        """
+        Get deleted project IDs by name using existing networks. Sometimes
+        tempest resources are left behind, this method will get the tempest
+        networks that don't have an existing project anymore and return
+        those project IDs.
+
+        :param str name: project and network name prefix
+        :rtype: list(str)
+        :return: list of project IDs
+        """
+        name = name or self.project_name
+
+        project_ids = self.get_project_ids(name=name)
+
+        # Using the networks resource to get the deleted project IDs
+        networks = self.network.get_networks(name=name)
+        deleted_project_ids = []
+
+        for network in networks:
+            if network.project_id not in project_ids:
+                deleted_project_ids.append(network.project_id)
+
+        return deleted_project_ids
+
+    def get_all_project_ids(self, name=None):
+        """
+        Get existing and deleted project IDs by name.
+
+        :param str name: project and network name prefix
+        :rtype: list(str)
+        :return: list of project IDs
+        """
+        name = name or self.project_name
+
+        result = self.get_project_ids(name=name)
+        deleted_project_ids = self.get_deleted_project_ids(name=name)
+        result.extend(deleted_project_ids)
+
+        return result
+
+    # TODO: find a fix, currently throwing the following exception,
+    # UnableToDeleteResource: The delete method is not supported for
+    # openstack.compute.v2.server.ServerDetail
+    def delete_servers(self, project_name=None,
+                       project_ids=None, server_name=None,
+                       print_delete=True, raise_exception=False):
+        """
+        Delete servers filtered by project name, project IDs and/or
+        server names. If NOT given the deletes are done by the project IDs
+        with the name at the self.project_name attribute.
+
+        :param str project_name: project name to filter by (can be None)
+        :param list project_ids: delete only servers within these projects.
+        :param str server_name: server name to filter by.
+        :param bool print_delete: print the resource name and ID.
+        :param bool raise_exception: flag to raise an Exception if True.
+        :return: list of undeleted servers(s)
+        """
+        if not project_ids and not server_name:
+            project_name = project_name or self.project_name
+            project_ids = self.get_all_project_ids(name=project_name)
+
+        result = self.compute.delete_resources(
+            resource_type=SERVERS, project_ids=project_ids, name=server_name,
+            print_delete=print_delete, raise_exception=raise_exception)
+
+        return result
+
+    def delete_networks(self, project_name=None,
+                        project_ids=None, network_name=None,
+                        print_delete=True, raise_exception=False):
+        """
+        Delete networks filtered by project name, project IDs and/or
+        network names. If NOT given the deletes are done by the project IDs
+        with the name at the self.project_name attribute.
+
+        :param str project_name: project name to filter by (can be None)
+        :param list project_ids: delete only networks within these projects.
+        :param str network_name: network name to filter by.
+        :param bool print_delete: print the resource name and ID.
+        :param bool raise_exception: flag to raise an Exception if True.
+        :return: list of undeleted network(s)
+        """
+        if not project_ids and not network_name:
+            project_name = project_name or self.project_name
+            project_ids = self.get_all_project_ids(name=project_name)
+
+        result = self.network.delete_resources(
+            resource_type=NETWORKS, project_ids=project_ids, name=network_name,
+            print_delete=print_delete, raise_exception=raise_exception)
+
+        return result
+
+    def delete_ports(self, project_name=None, project_ids=None,
+                     port_name=None, print_delete=True, raise_exception=False):
+        """
+        Delete ports filtered by project name, project IDs and/or
+        port names. If NOT given the deletes are done by the project IDs
+        with the name at the self.project_name attribute.
+
+        :param str project_name: project name to filter by (can be None)
+        :param list project_ids: delete only ports within these projects.
+        :param str port_name: port name to filter by.
+        :param bool print_delete: print the resource name and ID.
+        :param bool raise_exception: flag to raise an Exception if True.
+        :return: list of undeleted port(s)
+        """
+        if not project_ids and not port_name:
+            project_name = project_name or self.project_name
+            project_ids = self.get_all_project_ids(name=project_name)
+
+        result = self.network.delete_resources(
+            resource_type=PORTS, project_ids=project_ids, name=port_name,
+            print_delete=print_delete, raise_exception=raise_exception)
+
+        return result
+
+    def delete_security_groups(self, project_name=None,
+                               project_ids=None, sec_group_name=None,
+                               print_delete=True, raise_exception=False):
+        """
+        Delete sec groups filtered by project name, project IDs and/or
+        sec group names. If NOT given the deletes are done by the project IDs
+        with the name at the self.project_name attribute.
+
+        Default security groups need to be deleted after their project is
+        deleted and they will need to be targeted by the deleted project ID
+        or name.
+
+        :param str project_name: project name to filter by (can be None)
+        :param list project_ids: delete only ports within these projects.
+        :param str sec_group_name: security group name to filter by.
+        :param bool print_delete: print the resource name and ID.
+        :param bool raise_exception: flag to raise an Exception if True.
+        :return: list of undeleted security groups(s)
+        """
+        if not project_ids and not sec_group_name:
+            project_name = project_name or self.project_name
+            project_ids = self.get_all_project_ids(name=project_name)
+
+        result = self.network.delete_resources(
+            resource_type=SECURITY_GROUPS, project_ids=project_ids,
+            name=sec_group_name, print_delete=print_delete,
+            raise_exception=raise_exception)
+
+        return result
+
+    def delete_load_balancers(self, project_name=None,
+                              project_ids=None, lb_name=None,
+                              print_delete=True, raise_exception=False):
+        """
+        Delete lbs filtered by project name, project IDs and/or
+        lb names. If NOT given the deletes are done by the project IDs
+        with the name at the self.project_name attribute.
+
+        :param str project_name: project name to filter by (can be None)
+        :param list project_ids: delete only lbs within these projects.
+        :param str lb_name: loadbalancer name to filter by.
+        :param bool print_delete: print the resource name and ID.
+        :param bool raise_exception: flag to raise an Exception if True.
+        :return: list of undeleted load balancers(s)
+        """
+        if not project_ids and not lb_name:
+            project_name = project_name or self.project_name
+            project_ids = self.get_all_project_ids(name=project_name)
+
+        result = self.loadbalancer.delete_resources(
+            resource_type=LOAD_BALANCERS, project_ids=project_ids,
+            name=lb_name, print_delete=print_delete,
+            raise_exception=raise_exception)
+
+        return result
+
+    def delete_projects(self, name=None, print_delete=True,
+                        raise_exception=False):
+        """
+        Delete projects filtered by project name. ID is an invalid query
+        param for projects so the project_ids param can not be used here.
+
+        :param str name: project name to filter by (can be None)
+        :param bool print_delete: print the resource name and ID.
+        :param bool raise_exception: flag to raise an Exception if True.
+        :return: list of undeleted projects(s)
+        """
+        name = name or self.project_name
+
+        result = self.identity.delete_resources(
+            resource_type=PROJECTS, name=name, print_delete=print_delete,
+            raise_exception=raise_exception)
+
+        return result
+
+    def delete_users(self, project_name=None,
+                     project_ids=None, user_name=None,
+                     print_delete=True, raise_exception=False):
+        """
+        Delete users filtered by project name, project IDs and/or
+        user names. If NOT given the deletes are done by the project IDs
+        with the name at the self.project_name attribute.
+
+        :param str project_name: project name to filter by (can be None)
+        :param list project_ids: delete only users within these projects.
+        :param str user_name: user name to filter by.
+        :param bool print_delete: print the resource name and ID.
+        :param bool raise_exception: flag to raise an Exception if True.
+        :return: list of undeleted user(s)
+        """
+        if not project_ids and not user_name:
+            project_name = project_name or self.project_name
+            project_ids = self.get_all_project_ids(name=project_name)
+
+        result = self.identity.delete_resources(
+            resource_type=USERS, project_ids=project_ids,
+            name=user_name, print_delete=print_delete,
+            raise_exception=raise_exception)
+
+        return result


### PR DESCRIPTION
- OpenStack client sdk wrappers for GET methods that
  filter by resource names and project IDs for: identity, compute,
  loadbalancers and networks (including ports and sec groups)
- Base sdk class to be inherited by sdk wrappers
- Exceptions module
- Minimal and simple config module to get values from env variables
- clouds_example.yaml file as an example of a clouds.yaml file used
  by the Base sdk to create the connection object. It will use the
  cloud name from the self.config.openstack_cloud attribute.
- Utilities module with delete methods that can target by
  project names, project IDs and/or resource names.